### PR TITLE
refactor node view

### DIFF
--- a/deploy/rhos-dashboard.yaml
+++ b/deploy/rhos-dashboard.yaml
@@ -25,18 +25,8 @@ spec:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 1,
-      "iteration": 1605888772997,
-      "links": [
-        {
-          "icon": "external link",
-          "tags": [
-            "CloudView"
-          ],
-          "targetBlank": false,
-          "type": "dashboards",
-          "url": ""
-        }
-      ],
+      "iteration": 1606146495921,
+      "links": [],
       "panels": [
         {
           "collapsed": false,
@@ -527,14 +517,14 @@ spec:
           "options": {
             "fieldOptions": {
               "calcs": [
-                "lastNotNull"
+                "last"
               ],
               "defaults": {
                 "mappings": [
                   {
                     "id": 0,
                     "op": "=",
-                    "text": "N/A",
+                    "text": "0.0%",
                     "type": 1,
                     "value": "null"
                   }
@@ -548,12 +538,8 @@ spec:
                     "value": null
                   },
                   {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "value": 90
-                  },
-                  {
                     "color": "#d44a3a",
-                    "value": 95
+                    "value": 80
                   }
                 ],
                 "unit": "percent"
@@ -596,7 +582,7 @@ spec:
           "options": {
             "fieldOptions": {
               "calcs": [
-                "lastNotNull"
+                "last"
               ],
               "defaults": {
                 "decimals": 1,
@@ -604,7 +590,7 @@ spec:
                   {
                     "id": 0,
                     "op": "=",
-                    "text": "N/A",
+                    "text": "0.0%",
                     "type": 1,
                     "value": "null"
                   }
@@ -618,12 +604,8 @@ spec:
                     "value": null
                   },
                   {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "value": 0.9
-                  },
-                  {
                     "color": "#d44a3a",
-                    "value": 0.95
+                    "value": 0.8
                   }
                 ],
                 "unit": "percentunit"
@@ -933,7 +915,7 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 8,
             "x": 0,
             "y": 16
@@ -946,8 +928,8 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
-            "show": false,
+            "rightSide": false,
+            "show": true,
             "total": false,
             "values": true
           },
@@ -1034,7 +1016,7 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 8,
             "x": 8,
             "y": 16
@@ -1044,13 +1026,13 @@ spec:
           "legend": {
             "alignAsTable": true,
             "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": false,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -1119,7 +1101,7 @@ spec:
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": true
+              "show": false
             }
           ],
           "yaxis": {
@@ -1137,7 +1119,7 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 6,
+            "h": 8,
             "w": 8,
             "x": 16,
             "y": 16
@@ -1150,8 +1132,8 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
-            "show": false,
+            "rightSide": false,
+            "show": true,
             "total": false,
             "values": true
           },
@@ -1237,7 +1219,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 22
+            "y": 24
           },
           "id": 21,
           "panels": [],
@@ -1254,10 +1236,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
+            "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 2,
@@ -1347,10 +1329,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
+            "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 15,
@@ -1360,8 +1342,8 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
-            "show": false,
+            "rightSide": false,
+            "show": true,
             "total": false,
             "values": true
           },
@@ -1438,7 +1420,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 33
           },
           "id": 25,
           "panels": [],
@@ -1459,7 +1441,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 27,
@@ -1469,8 +1451,8 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
-            "show": true,
+            "rightSide": false,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -1550,9 +1532,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 12,
+            "w": 9,
             "x": 12,
-            "y": 29
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 23,
@@ -1561,7 +1543,7 @@ spec:
             "current": false,
             "max": false,
             "min": false,
-            "show": true,
+            "show": false,
             "total": false,
             "values": false
           },
@@ -1583,7 +1565,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(collectd_hugepages_vmpage_number{type_instance=\"free\",host=\"$hosts\"})",
+              "expr": "sum(collectd_hugepages_vmpage_number{type_instance=\"used\",host=\"$hosts\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{hugepages}}",
@@ -1632,13 +1614,76 @@ spec:
           }
         },
         {
+          "cacheTimeout": null,
+          "datasource": "STFPrometheus",
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 21,
+            "y": 34
+          },
+          "id": 71,
+          "links": [],
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "last"
+              ],
+              "defaults": {
+                "mappings": [
+                  {
+                    "id": 0,
+                    "op": "=",
+                    "text": "0.0%",
+                    "type": 1,
+                    "value": "null"
+                  }
+                ],
+                "max": 1,
+                "min": 0,
+                "nullValueMode": "connected",
+                "thresholds": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ],
+                "unit": "percentunit"
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.5.1",
+          "targets": [
+            {
+              "expr": "sum(collectd_hugepages_vmpage_number{type_instance=\"used\",host=\"$hosts\"}) / sum(collectd_hugepages_vmpage_number{host=\"$hosts\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{hugepages}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Huge Pages (%)",
+          "type": "gauge"
+        },
+        {
           "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 39
           },
           "id": 11,
           "panels": [],
@@ -1650,10 +1695,10 @@ spec:
           "datasource": "STFPrometheus",
           "description": "",
           "gridPos": {
-            "h": 5,
-            "w": 8,
+            "h": 8,
+            "w": 6,
             "x": 0,
-            "y": 35
+            "y": 40
           },
           "id": 51,
           "links": [],
@@ -1709,10 +1754,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
-            "w": 16,
-            "x": 8,
-            "y": 35
+            "h": 8,
+            "w": 18,
+            "x": 6,
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 9,
@@ -1722,7 +1767,7 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": true
@@ -1799,7 +1844,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 48
           },
           "id": 70,
           "panels": [],
@@ -1817,10 +1862,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
+            "h": 6,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 13,
@@ -1831,7 +1876,7 @@ spec:
             "hideZero": false,
             "max": true,
             "min": true,
-            "rightSide": true,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": true
@@ -1920,10 +1965,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
+            "h": 6,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 4,
@@ -1933,7 +1978,7 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": true
@@ -2021,10 +2066,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
+            "h": 6,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 55
           },
           "hiddenSeries": false,
           "id": 17,
@@ -2034,7 +2079,7 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": true
@@ -2123,10 +2168,10 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 5,
+            "h": 6,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 55
           },
           "hiddenSeries": false,
           "id": 16,
@@ -2136,7 +2181,7 @@ spec:
             "current": true,
             "max": true,
             "min": true,
-            "rightSide": true,
+            "rightSide": false,
             "show": true,
             "total": false,
             "values": true
@@ -2224,11 +2269,6 @@ spec:
         "list": [
           {
             "allValue": null,
-            "current": {
-              "selected": true,
-              "text": "controller-0.redhat.local",
-              "value": "controller-0.redhat.local"
-            },
             "datasource": "STFPrometheus",
             "definition": "label_values(host)",
             "hide": 0,
@@ -2251,7 +2291,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-24h",
+        "from": "now-12h",
         "to": "now"
       },
       "timepicker": {
@@ -2282,5 +2322,5 @@ spec:
       "timezone": "",
       "title": "Infrastructure Node View",
       "uid": "1F1OJZEWz",
-      "version": 24
+      "version": 26
     }

--- a/deploy/rhos-dashboard.yaml
+++ b/deploy/rhos-dashboard.yaml
@@ -25,7 +25,7 @@ spec:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 1,
-      "iteration": 1606146495921,
+      "iteration": 1606152811123,
       "links": [],
       "panels": [
         {
@@ -870,11 +870,12 @@ spec:
           },
           "yaxes": [
             {
+              "decimals": null,
               "format": "short",
               "label": "Processes",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1302,7 +1303,7 @@ spec:
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1396,7 +1397,7 @@ spec:
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1504,7 +1505,7 @@ spec:
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1596,7 +1597,7 @@ spec:
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1937,7 +1938,7 @@ spec:
               "label": "",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2038,7 +2039,7 @@ spec:
               "label": "",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2141,7 +2142,7 @@ spec:
               "label": "",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2243,7 +2244,7 @@ spec:
               "label": "",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -2322,5 +2323,5 @@ spec:
       "timezone": "",
       "title": "Infrastructure Node View",
       "uid": "1F1OJZEWz",
-      "version": 26
+      "version": 28
     }

--- a/deploy/rhos-dashboard.yaml
+++ b/deploy/rhos-dashboard.yaml
@@ -24,8 +24,8 @@ spec:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 2,
-      "iteration": 1585934380646,
+      "id": 1,
+      "iteration": 1605888772997,
       "links": [
         {
           "icon": "external link",
@@ -39,6 +39,20 @@ spec:
       ],
       "panels": [
         {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 64,
+          "panels": [],
+          "title": "Alerts",
+          "type": "row"
+        },
+        {
           "cacheTimeout": null,
           "columns": [],
           "datasource": "STFPrometheus",
@@ -48,7 +62,7 @@ spec:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 0
+            "y": 1
           },
           "id": 61,
           "links": [],
@@ -183,7 +197,7 @@ spec:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 0
+            "y": 1
           },
           "id": 62,
           "links": [],
@@ -309,6 +323,20 @@ spec:
           "type": "table"
         },
         {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 68,
+          "panels": [],
+          "title": "Quickview",
+          "type": "row"
+        },
+        {
           "cacheTimeout": null,
           "colorBackground": true,
           "colorPostfix": false,
@@ -320,7 +348,7 @@ spec:
             "#C4162A"
           ],
           "datasource": null,
-          "description": "Shows whether any metrics at all were received for this Node during the time period.",
+          "description": "",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -330,10 +358,10 @@ spec:
             "thresholdMarkers": true
           },
           "gridPos": {
-            "h": 2,
-            "w": 24,
+            "h": 5,
+            "w": 2,
             "x": 0,
-            "y": 8
+            "y": 10
           },
           "id": 33,
           "interval": null,
@@ -420,9 +448,9 @@ spec:
             "thresholdMarkers": true
           },
           "gridPos": {
-            "h": 3,
-            "w": 24,
-            "x": 0,
+            "h": 5,
+            "w": 2,
+            "x": 2,
             "y": 10
           },
           "id": 31,
@@ -486,6 +514,211 @@ spec:
         },
         {
           "cacheTimeout": null,
+          "datasource": "STFPrometheus",
+          "description": "",
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 4,
+            "y": 10
+          },
+          "id": 19,
+          "links": [],
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "defaults": {
+                "mappings": [
+                  {
+                    "id": 0,
+                    "op": "=",
+                    "text": "N/A",
+                    "type": 1,
+                    "value": "null"
+                  }
+                ],
+                "max": 100,
+                "min": 0,
+                "nullValueMode": "connected",
+                "thresholds": [
+                  {
+                    "color": "#299c46",
+                    "value": null
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 90
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 95
+                  }
+                ],
+                "unit": "percent"
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.5.1",
+          "targets": [
+            {
+              "expr": "sum(collectd_cpu_percent{type_instance!=\"idle\", host=\"$hosts\"}) / count(sum by (type_instance) (collectd_cpu_percent{type_instance!=\"idle\",host=\"$hosts\"}))",
+              "format": "time_series",
+              "instant": true,
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU",
+          "type": "gauge"
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "STFPrometheus",
+          "description": "",
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 7,
+            "y": 10
+          },
+          "id": 44,
+          "links": [],
+          "options": {
+            "fieldOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "defaults": {
+                "decimals": 1,
+                "mappings": [
+                  {
+                    "id": 0,
+                    "op": "=",
+                    "text": "N/A",
+                    "type": 1,
+                    "value": "null"
+                  }
+                ],
+                "max": 1,
+                "min": 0,
+                "nullValueMode": "connected",
+                "thresholds": [
+                  {
+                    "color": "#299c46",
+                    "value": null
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 0.9
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 0.95
+                  }
+                ],
+                "unit": "percentunit"
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal",
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true
+          },
+          "pluginVersion": "6.5.1",
+          "targets": [
+            {
+              "expr": "sum(collectd_memory{type_instance=\"used\",host=\"$hosts\"})/ sum(collectd_memory{host=\"$hosts\"})",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{memory}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Memory",
+          "type": "gauge"
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "STFPrometheus",
+          "description": "",
+          "gridPos": {
+            "h": 5,
+            "w": 3,
+            "x": 10,
+            "y": 10
+          },
+          "id": 41,
+          "links": [],
+          "options": {
+            "displayMode": "gradient",
+            "fieldOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "defaults": {
+                "decimals": 0,
+                "mappings": [
+                  {
+                    "id": 0,
+                    "op": "=",
+                    "text": "N/A",
+                    "type": 1,
+                    "value": "null"
+                  }
+                ],
+                "max": 1,
+                "min": 0,
+                "nullValueMode": "connected",
+                "thresholds": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ],
+                "unit": "percentunit"
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal"
+          },
+          "pluginVersion": "6.5.1",
+          "targets": [
+            {
+              "expr": "sum(collectd_df_df_complex{host=\"$hosts\",type_instance=\"used\"}) by (plugin_instance) / sum(collectd_df_df_complex{host=\"$hosts\"}) by (plugin_instance)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{plugin_instance}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "File Systems",
+          "type": "bargauge"
+        },
+        {
+          "cacheTimeout": null,
           "colorBackground": false,
           "colorValue": false,
           "colors": [
@@ -494,7 +727,7 @@ spec:
             "#d44a3a"
           ],
           "datasource": "STFPrometheus",
-          "description": "Total number of CPUs cores on node",
+          "description": "",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -504,12 +737,12 @@ spec:
             "thresholdMarkers": true
           },
           "gridPos": {
-            "h": 7,
-            "w": 4,
-            "x": 0,
-            "y": 13
+            "h": 5,
+            "w": 3,
+            "x": 13,
+            "y": 10
           },
-          "id": 39,
+          "id": 54,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -542,107 +775,24 @@ spec:
             "fillColor": "rgba(31, 118, 189, 0.18)",
             "full": false,
             "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "count(sum(collectd_cpu_percent{host=\"$hosts\"}) by (plugin_instance))",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "CPU Cores",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "STFPrometheus",
-          "decimals": 1,
-          "description": "Total amount of memory on node",
-          "format": "bytes",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
             "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 4,
-            "x": 4,
-            "y": 13
-          },
-          "id": 40,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
+            "ymax": null,
+            "ymin": null
           },
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(collectd_memory{host=\"$hosts\"})",
+              "expr": "sum(collectd_interface_if_errors_rx_total{host=\"$hosts\"}) + sum(collectd_interface_if_errors_tx_total{host=\"$hosts\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{memory}}",
+              "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }
           ],
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Memory",
+          "title": "Interface Errors",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -652,174 +802,7 @@ spec:
               "value": "null"
             }
           ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "STFPrometheus",
-          "decimals": 1,
-          "description": "Aproxement total disk space available on to the root device on this node.\n\nDisclaimer: this query excludes the temporary filesystems (tmpfs,devtmpfs,overlay). Thus, if swap storage is used, these file systems may use disk space, causing this result to appear smaller than it should. ",
-          "format": "bytes",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 4,
-            "x": 8,
-            "y": 13
-          },
-          "id": 41,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(collectd_df_df_complex{plugin_instance!~\"devtmpfs|overlay|shm|tmpfs\",host=\"$hosts\"})",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "{{df}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Disk Size",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "columns": [
-            {
-              "text": "Current",
-              "value": "current"
-            }
-          ],
-          "datasource": null,
-          "description": "All existing proce",
-          "fontSize": "100%",
-          "gridPos": {
-            "h": 7,
-            "w": 5,
-            "x": 12,
-            "y": 13
-          },
-          "id": 49,
-          "links": [],
-          "options": {},
-          "pageSize": null,
-          "scroll": true,
-          "showHeader": true,
-          "sort": {
-            "col": 0,
-            "desc": true
-          },
-          "styles": [
-            {
-              "alias": "Time",
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "pattern": "Time",
-              "type": "date"
-            },
-            {
-              "alias": "Type",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "decimals": 2,
-              "pattern": "Metric",
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            },
-            {
-              "alias": "",
-              "colorMode": null,
-              "colors": [
-                "rgba(245, 54, 54, 0.9)",
-                "rgba(237, 129, 40, 0.89)",
-                "rgba(50, 172, 45, 0.97)"
-              ],
-              "dateFormat": "YYYY-MM-DD HH:mm:ss",
-              "decimals": 0,
-              "mappingType": 1,
-              "pattern": "Current",
-              "thresholds": [],
-              "type": "number",
-              "unit": "short"
-            }
-          ],
-          "targets": [
-            {
-              "expr": "collectd_processes_ps_state{host=\"$hosts\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{type_instance}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Processes",
-          "transform": "timeseries_aggregations",
-          "type": "table"
+          "valueName": "delta"
         },
         {
           "aliasColors": {},
@@ -827,14 +810,14 @@ spec:
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "description": "On Linux, load average represents the average number of running and uninterruptable processes residing in the kernel's execution queue. \n\nTypically, short term, midterm, and longterm series give running averages of 1m, 5m, and 15m, respectively. ",
+          "description": "Load average represents the average number of running and un-interruptable processes residing in the kernel's execution queue. \n\nTypically, short term, midterm, and long term series give running averages of 1m, 5m, and 15m, respectively. ",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 7,
-            "w": 7,
-            "x": 17,
-            "y": 13
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 10
           },
           "hiddenSeries": false,
           "id": 35,
@@ -933,573 +916,27 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 20
+            "y": 15
           },
           "id": 37,
           "panels": [],
-          "title": "Networking",
+          "title": "Network Interfaces",
           "type": "row"
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 4,
-            "x": 0,
-            "y": 21
-          },
-          "id": 54,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(collectd_interface_if_errors_rx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Physical Interfaces Ingress Errors",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "delta"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 4,
-            "x": 4,
-            "y": 21
-          },
-          "id": 55,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(collectd_interface_if_errors_tx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Physical Interfaces Egress Errors",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "delta"
-        },
-        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
           "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
+          "description": "",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 6,
             "w": 8,
-            "x": 8,
-            "y": 21
-          },
-          "hiddenSeries": false,
-          "id": 56,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(collectd_interface_if_errors_rx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Physical Interfaces Ingress Error Rates",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "label": "errors/s",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 8,
-            "x": 16,
-            "y": 21
-          },
-          "hiddenSeries": false,
-          "id": 57,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(collectd_interface_if_errors_tx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Physical Interfaces Egress Error Rates",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "label": "errors/s",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
             "x": 0,
-            "y": 27
-          },
-          "hiddenSeries": false,
-          "id": 58,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(collectd_interface_if_packets_rx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Physical Interfaces Packets Ingress",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 33
-          },
-          "hiddenSeries": false,
-          "id": 59,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(collectd_interface_if_packets_tx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Physical Interfaces Packets Egress",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "STFPrometheus",
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 39
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 48,
@@ -1510,7 +947,7 @@ spec:
             "max": true,
             "min": true,
             "rightSide": true,
-            "show": true,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -1525,24 +962,32 @@ spec:
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/Tx/",
+              "transform": "negative-Y"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(collectd_interface_if_octets_rx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
+              "expr": "rate(collectd_interface_if_octets_rx_total{host=\"$hosts\"}[10m])",
+              "legendFormat": "Rx {{plugin_instance}}",
               "refId": "A"
+            },
+            {
+              "expr": "rate(collectd_interface_if_octets_tx_total{host=\"$hosts\"}[10m])",
+              "legendFormat": "Tx {{plugin_instance}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Physical Interfaces Data Ingress",
+          "title": "Data",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1584,28 +1029,28 @@ spec:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": null,
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
+          "datasource": "STFPrometheus",
+          "description": "",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 45
+            "w": 8,
+            "x": 8,
+            "y": 16
           },
           "hiddenSeries": false,
-          "id": 43,
+          "id": 56,
           "legend": {
             "alignAsTable": true,
             "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
+            "current": false,
+            "max": false,
+            "min": false,
             "rightSide": true,
-            "show": true,
+            "show": false,
             "total": false,
-            "values": true
+            "values": false
           },
           "lines": true,
           "linewidth": 1,
@@ -1618,24 +1063,34 @@ spec:
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/Tx/",
+              "transform": "negative-Y"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(collectd_interface_if_octets_tx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
+              "expr": "rate(collectd_interface_if_errors_rx_total{host=\"$hosts\"}[10m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
+              "legendFormat": "Rx {{plugin_instance}}",
               "refId": "A"
+            },
+            {
+              "expr": "rate(collectd_interface_if_errors_tx_total{host=\"$hosts\"}[10m])",
+              "legendFormat": "Tx {{plugin_instance}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Physical Interfaces Data Egress",
+          "title": "Error Rates",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1651,8 +1106,8 @@ spec:
           },
           "yaxes": [
             {
-              "format": "Bps",
-              "label": null,
+              "format": "none",
+              "label": "errors/s",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -1678,14 +1133,14 @@ spec:
           "dashLength": 10,
           "dashes": false,
           "datasource": null,
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
+          "description": "",
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 51
+            "w": 8,
+            "x": 16,
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 53,
@@ -1696,7 +1151,7 @@ spec:
             "max": true,
             "min": true,
             "rightSide": true,
-            "show": true,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -1711,117 +1166,34 @@ spec:
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/Tx/",
+              "transform": "negative-Y"
+            }
+          ],
           "spaceLength": 10,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(collectd_interface_if_dropped_rx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
+              "expr": "rate(collectd_interface_if_dropped_rx_total{host=\"$hosts\"}[10m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
+              "legendFormat": "Rx {{plugin_instance}}",
               "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Physical Interfaces Drop Rate Ingress",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "pps",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
             },
             {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": null,
-          "description": "Disclaimer: query contains a set of typical hardware interfaces seen on Linux systems. Some unrecognized interfaces may not be included in the query.",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 57
-          },
-          "hiddenSeries": false,
-          "id": 52,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(collectd_interface_if_dropped_tx_total{plugin_instance=~\"eth.*|wlan.*|wlp.*|ens.*|enp.*\",host=\"$hosts\"}[10m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{plugin_instance}}",
-              "refId": "A"
+              "expr": "rate(collectd_interface_if_dropped_tx_total{host=\"$hosts\"}[10m])",
+              "legendFormat": "Tx {{plugin_instance}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Physical Interfaces Drop Rate Egress",
+          "title": "Drop Rates",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1865,81 +1237,12 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 63
+            "y": 22
           },
           "id": 21,
           "panels": [],
           "title": "CPU",
           "type": "row"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": "STFPrometheus",
-          "description": "",
-          "gridPos": {
-            "h": 5,
-            "w": 3,
-            "x": 0,
-            "y": 64
-          },
-          "id": 19,
-          "links": [],
-          "options": {
-            "fieldOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "defaults": {
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "N/A",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 100,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "#299c46",
-                    "value": null
-                  },
-                  {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "value": 90
-                  },
-                  {
-                    "color": "#d44a3a",
-                    "value": 95
-                  }
-                ],
-                "unit": "percent"
-              },
-              "override": {},
-              "values": false
-            },
-            "orientation": "horizontal",
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true
-          },
-          "pluginVersion": "6.5.1",
-          "targets": [
-            {
-              "expr": "sum(collectd_cpu_percent{type_instance!=\"idle\", host=\"$hosts\"}) / count(sum by (type_instance) (collectd_cpu_percent{type_instance!=\"idle\",host=\"$hosts\"}))",
-              "format": "time_series",
-              "instant": true,
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Current CPU Usage",
-          "type": "gauge"
         },
         {
           "aliasColors": {},
@@ -1952,9 +1255,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 69
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 2,
@@ -1997,7 +1300,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Aggregate CPU Usage",
+          "title": "Aggr. Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2045,9 +1348,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 74
+            "w": 12,
+            "x": 12,
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 15,
@@ -2058,7 +1361,7 @@ spec:
             "max": true,
             "min": true,
             "rightSide": true,
-            "show": true,
+            "show": false,
             "total": false,
             "values": true
           },
@@ -2091,7 +1394,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Aggr. CPU Usage by Type",
+          "title": "Aggr. Usage by Type",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2135,169 +1438,12 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 79
+            "y": 28
           },
           "id": 25,
           "panels": [],
           "title": "Memory",
           "type": "row"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": "STFPrometheus",
-          "description": "",
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 0,
-            "y": 80
-          },
-          "id": 44,
-          "links": [],
-          "options": {
-            "fieldOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "defaults": {
-                "decimals": 1,
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "N/A",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 1,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "#299c46",
-                    "value": null
-                  },
-                  {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "value": 0.9
-                  },
-                  {
-                    "color": "#d44a3a",
-                    "value": 0.95
-                  }
-                ],
-                "unit": "percentunit"
-              },
-              "override": {},
-              "values": false
-            },
-            "orientation": "horizontal",
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true
-          },
-          "pluginVersion": "6.5.1",
-          "targets": [
-            {
-              "expr": "sum(collectd_memory{type_instance=\"used\",host=\"$hosts\"})/ sum(collectd_memory{host=\"$hosts\"})",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "{{memory}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Memory Used",
-          "type": "gauge"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "STFPrometheus",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 3,
-            "y": 80
-          },
-          "id": 23,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "pluginVersion": "6.5.2",
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(collectd_hugepages_vmpage_number{type_instance=\"used\",host=\"$hosts\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{hugepages}}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Huge Pages Used",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
         },
         {
           "aliasColors": {},
@@ -2311,9 +1457,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 86
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 27,
@@ -2394,17 +1540,109 @@ spec:
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "STFPrometheus",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 23,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pluginVersion": "6.5.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(collectd_hugepages_vmpage_number{type_instance=\"free\",host=\"$hosts\"})",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{hugepages}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Huge Pages",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 91
+            "y": 34
           },
           "id": 11,
           "panels": [],
-          "title": "Disk/File System",
+          "title": "File System",
           "type": "row"
         },
         {
@@ -2412,113 +1650,32 @@ spec:
           "datasource": "STFPrometheus",
           "description": "",
           "gridPos": {
-            "h": 6,
-            "w": 3,
+            "h": 5,
+            "w": 8,
             "x": 0,
-            "y": 92
-          },
-          "id": 50,
-          "links": [],
-          "options": {
-            "fieldOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "defaults": {
-                "decimals": 1,
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "N/A",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 1,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "#299c46",
-                    "value": null
-                  },
-                  {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "value": 0.9
-                  },
-                  {
-                    "color": "#d44a3a",
-                    "value": 0.95
-                  }
-                ],
-                "unit": "percentunit"
-              },
-              "override": {},
-              "values": false
-            },
-            "orientation": "horizontal",
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true
-          },
-          "pluginVersion": "6.5.1",
-          "targets": [
-            {
-              "expr": "sum(collectd_df_df_complex{plugin_instance!~\"devtmpfs|overlay|shm|tmpfs\",type_instance!=\"free\",host=\"$hosts\"})/sum(collectd_df_df_complex{plugin_instance!~\"devtmpfs|overlay|shm|tmpfs\",host=\"$hosts\"})",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Disk Space Usage",
-          "type": "gauge"
-        },
-        {
-          "cacheTimeout": null,
-          "datasource": "STFPrometheus",
-          "description": "",
-          "gridPos": {
-            "h": 6,
-            "w": 3,
-            "x": 3,
-            "y": 92
+            "y": 35
           },
           "id": 51,
           "links": [],
           "options": {
+            "displayMode": "gradient",
             "fieldOptions": {
               "calcs": [
-                "lastNotNull"
+                "last"
               ],
               "defaults": {
-                "decimals": 1,
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "N/A",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
+                "decimals": 2,
+                "mappings": [],
                 "max": 1,
                 "min": 0,
-                "nullValueMode": "connected",
                 "thresholds": [
                   {
-                    "color": "#299c46",
+                    "color": "green",
                     "value": null
                   },
                   {
-                    "color": "rgba(237, 129, 40, 0.89)",
-                    "value": 0.9
-                  },
-                  {
-                    "color": "#d44a3a",
-                    "value": 0.95
+                    "color": "red",
+                    "value": 80
                   }
                 ],
                 "unit": "percentunit"
@@ -2526,24 +1683,22 @@ spec:
               "override": {},
               "values": false
             },
-            "orientation": "horizontal",
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "orientation": "horizontal"
           },
           "pluginVersion": "6.5.1",
           "targets": [
             {
-              "expr": "sum(collectd_df_df_inodes{type_instance=\"used\", host=\"$hosts\"}) / sum(collectd_df_df_inodes{host=\"$hosts\"})",
+              "expr": "sum by (plugin_instance) (collectd_df_df_inodes{type_instance=\"used\", host=\"$hosts\"}) / sum by (plugin_instance) (collectd_df_df_inodes{host=\"$hosts\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "",
+              "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
           "title": "Inode Usage",
-          "type": "gauge"
+          "type": "bargauge"
         },
         {
           "aliasColors": {},
@@ -2555,9 +1710,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 98
+            "w": 16,
+            "x": 8,
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 9,
@@ -2589,10 +1744,10 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (type_instance) (collectd_df_df_complex{plugin_instance!~\"devtmpfs|overlay|shm|tmpfs\",type_instance!~\"free\",host=\"$hosts\"})",
+              "expr": "sum by (plugin_instance) (collectd_df_df_complex{type_instance!~\"free\",host=\"$hosts\"})",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{type_instance}}",
+              "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }
           ],
@@ -2600,7 +1755,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Aggregate Disk Space Usage",
+          "title": "File System Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2638,6 +1793,20 @@ spec:
           }
         },
         {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 40
+          },
+          "id": 70,
+          "panels": [],
+          "title": "Disk",
+          "type": "row"
+        },
+        {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
@@ -2649,9 +1818,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 103
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 13,
@@ -2702,7 +1871,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Disk Traffic",
+          "title": "Traffic",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2752,9 +1921,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 108
+            "w": 12,
+            "x": 12,
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 4,
@@ -2803,7 +1972,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Disk Load",
+          "title": "Load",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2853,9 +2022,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 113
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 17,
@@ -2955,9 +2124,9 @@ spec:
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 24,
-            "x": 0,
-            "y": 118
+            "w": 12,
+            "x": 12,
+            "y": 46
           },
           "hiddenSeries": false,
           "id": 16,
@@ -3009,7 +2178,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Average I/O Operation Time",
+          "title": "Avg. I/O Operation Time",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -3047,7 +2216,7 @@ spec:
           }
         }
       ],
-      "refresh": "10s",
+      "refresh": "1m",
       "schemaVersion": 21,
       "style": "dark",
       "tags": [],
@@ -3056,7 +2225,7 @@ spec:
           {
             "allValue": null,
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "controller-0.redhat.local",
               "value": "controller-0.redhat.local"
             },
@@ -3082,7 +2251,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-5m",
+        "from": "now-24h",
         "to": "now"
       },
       "timepicker": {
@@ -3113,5 +2282,5 @@ spec:
       "timezone": "",
       "title": "Infrastructure Node View",
       "uid": "1F1OJZEWz",
-      "version": 12
+      "version": 24
     }


### PR DESCRIPTION
Here's a re factor and consolidation of the infrastructure node view dashboard. This gets rid of a lot of the redundant panels that existed in the old version as well as the panels describing the characteristics of the system (total CPU cores, total memory, and the always wrong total disk size). IMO, this information is not all that useful to monitoring node performance and just takes up space. The new `Quickview` section contains useful information at a glance, and the following sections dig deeper into their respective categories. On the interface panels, Rx and Tx directions are combined into a single panel, with Tx values showing up as a negative value. This allows more information to be displayed with less space. 

Additionally, all attempts to calculate disk size based on the size of the mounted file systems have been thrown out for two reasons:
1. It's nearly impossible to build a query that can figure out hardware disk size based on file systems in all environments
2. The information is not useful.
It is more useful to measure how much of each partition is being used. Thus, I replaced all attempts to determine how much of the disk is used with how much of each file system is used. This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1843667

![image](https://user-images.githubusercontent.com/41337120/99824809-34d31d80-2b24-11eb-947b-4c0e387da334.png)
