### PR TITLE
Cloud dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ Service Telemetry Framework.
 Deploying a Grafana instance requires the deployment of the Grafana Operator
 first from the Community Operators catalog source. Then, run the following:
 
-```
+```bash
 oc create -f deploy/subscription.yaml \
-    -f deploy/rhos-dashboard.yaml \
-    -f deploy/grafana.yaml
+        -f deploy/grafana.yaml
 
+# datasources
 ES_PASSWORD=$(oc get secret elasticsearch-es-elastic-user \
 -ogo-template='{{ .data.elastic | base64decode }}') && \
 sed "s/ES_PASSWORD/$ES_PASSWORD/g" deploy/datasource.yaml | oc apply -f -
 
+# dashboards
+oc create -f deploy/rhos-dashboard.yaml \
+        -f deploy/rhos-cloud-dashboard.yaml
+
+# vm dashboard [WIP]
+oc create -f contrib/vm-view.yaml
 ```

--- a/deploy/datasource.yaml
+++ b/deploy/datasource.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: service-telemetry
 spec:
   datasources:
-    - name: STFElasticsearch
+    - name: es_collectd
       access: proxy
       editable: true
       isDefault: false
@@ -14,12 +14,27 @@ spec:
       basicAuth: true
       basicAuthUser: elastic
       basicAuthPassword: ES_PASSWORD
-      database: collectd_checks
+      database: collectd_*
       jsonData:
         tlsSkipVerify: true
         timeField: startsAt
         esVersion: 70
         
+    - name: es_ceilometer
+      access: proxy
+      editable: true
+      isDefault: false
+      url: 'https://elasticsearch-es-http:9200'
+      type: elasticsearch
+      basicAuth: true
+      basicAuthUser: elastic
+      basicAuthPassword: ES_PASSWORD
+      database: ceilometer_*
+      jsonData:
+        tlsSkipVerify: true
+        timeField: startsAt
+        esVersion: 70
+
     - name: STFPrometheus
       type: prometheus
       access: proxy

--- a/deploy/rhos-cloud-dashboard.yaml
+++ b/deploy/rhos-cloud-dashboard.yaml
@@ -25,22 +25,30 @@ spec:
             "name": "Annotations & Alerts",
             "showIn": 0,
             "type": "dashboard"
+          },
+          {
+            "datasource": "es_ceilometer",
+            "enable": true,
+            "hide": false,
+            "iconColor": "rgba(255, 96, 96, 1)",
+            "limit": 100,
+            "name": "volume_alert",
+            "query": "_index:ceilometer_volume_*",
+            "showIn": 0,
+            "tags": [],
+            "textField": "Volume Event",
+            "timeEndField": "",
+            "timeField": "payload.generated",
+            "type": "tags"
           }
         ]
       },
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 2,
-      "iteration": 1606250232524,
-      "links": [
-        {
-          "asDropdown": true,
-          "icon": "external link",
-          "tags": [],
-          "type": "dashboards"
-        }
-      ],
+      "id": 1,
+      "iteration": 1606335117051,
+      "links": [],
       "panels": [
         {
           "cacheTimeout": null,
@@ -58,9 +66,9 @@ spec:
             "mode": "opacity"
           },
           "dataFormat": "tsbuckets",
-          "datasource": "ceilometer_compute_instance",
+          "datasource": "es_collectd",
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 15,
             "x": 0,
             "y": 0
@@ -221,7 +229,7 @@ spec:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "API Statuses",
+          "title": "Uptime",
           "tooltip": {
             "show": true,
             "showHistogram": false
@@ -246,28 +254,178 @@ spec:
           "yBucketSize": null
         },
         {
-          "dashboardFilter": "",
-          "dashboardTags": [],
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
-          "folderId": null,
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 11,
+            "h": 6,
             "w": 9,
             "x": 15,
             "y": 0
           },
-          "id": 4,
-          "limit": 10,
-          "nameFilter": "",
-          "onlyAlertsOnDashboard": false,
-          "options": {},
-          "show": "current",
-          "sortOrder": 1,
-          "stateFilter": [],
+          "hiddenSeries": false,
+          "id": 42,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(3, sum by (plugin_instance, host) (collectd_libpodstats_pod_memory))",
+              "legendFormat": "{{plugin_instance}} on {{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
-          "title": "All Alerts",
-          "type": "alertlist"
+          "title": "Top 3 Memory Consumers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 15,
+            "y": 6
+          },
+          "hiddenSeries": false,
+          "id": 43,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(3, avg_over_time(collectd_libpodstats_pod_cpu_percent[10m]))",
+              "legendFormat": "{{plugin_instance}} on {{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Top 3 CPU Consumers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "cacheTimeout": null,
@@ -278,7 +436,7 @@ spec:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "ceilometer_compute_instance",
+          "datasource": "es_collectd",
           "decimals": null,
           "format": "percentunit",
           "gauge": {
@@ -292,7 +450,7 @@ spec:
             "h": 4,
             "w": 3,
             "x": 0,
-            "y": 7
+            "y": 8
           },
           "id": 29,
           "interval": null,
@@ -386,7 +544,7 @@ spec:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "ceilometer_compute_instance",
+          "datasource": "es_collectd",
           "decimals": null,
           "format": "percentunit",
           "gauge": {
@@ -400,7 +558,7 @@ spec:
             "h": 4,
             "w": 3,
             "x": 3,
-            "y": 7
+            "y": 8
           },
           "id": 30,
           "interval": null,
@@ -494,7 +652,7 @@ spec:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "ceilometer_compute_instance",
+          "datasource": "es_collectd",
           "decimals": null,
           "format": "percentunit",
           "gauge": {
@@ -508,7 +666,7 @@ spec:
             "h": 4,
             "w": 3,
             "x": 6,
-            "y": 7
+            "y": 8
           },
           "id": 31,
           "interval": null,
@@ -602,7 +760,7 @@ spec:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "ceilometer_compute_instance",
+          "datasource": "es_collectd",
           "decimals": null,
           "format": "percentunit",
           "gauge": {
@@ -616,7 +774,7 @@ spec:
             "h": 4,
             "w": 3,
             "x": 9,
-            "y": 7
+            "y": 8
           },
           "id": 26,
           "interval": null,
@@ -710,7 +868,7 @@ spec:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "ceilometer_compute_instance",
+          "datasource": "es_collectd",
           "decimals": null,
           "format": "percentunit",
           "gauge": {
@@ -724,7 +882,7 @@ spec:
             "h": 4,
             "w": 3,
             "x": 12,
-            "y": 7
+            "y": 8
           },
           "id": 32,
           "interval": null,
@@ -816,7 +974,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 11
+            "y": 12
           },
           "id": 23,
           "panels": [],
@@ -830,13 +988,13 @@ spec:
             "#d44a3a",
             "#4040a0"
           ],
-          "datasource": null,
+          "datasource": "STFPrometheus",
           "description": "Click instance for drill down view",
           "gridPos": {
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
           "id": 17,
           "links": [],
@@ -869,7 +1027,7 @@ spec:
             "globalDecimals": 2,
             "globalDisplayMode": "all",
             "globalDisplayTextTriggeredEmpty": "OK",
-            "globalOperatorName": "avg",
+            "globalOperatorName": "current",
             "globalUnitFormat": "short",
             "gradientEnabled": false,
             "hexagonSortByDirection": 1,
@@ -937,9 +1095,6 @@ spec:
           "targets": [
             {
               "expr": "ceilometer_cpu{project=\"$projects\"}",
-              "format": "time_series",
-              "instant": false,
-              "intervalFactor": 1,
               "legendFormat": "{{resource}}",
               "refId": "A"
             }
@@ -963,15 +1118,15 @@ spec:
             "#d44a3a",
             "#4040a0"
           ],
-          "datasource": null,
+          "datasource": "STFPrometheus",
           "description": "Click instance for drill down view",
           "gridPos": {
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 13
           },
-          "id": 28,
+          "id": 44,
           "links": [],
           "mappingType": 1,
           "mappingTypes": [
@@ -1036,7 +1191,7 @@ spec:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1606250232524,
+          "repeatIteration": 1606335117051,
           "repeatPanelId": 17,
           "savedComposites": [],
           "savedOverrides": [
@@ -1072,9 +1227,6 @@ spec:
           "targets": [
             {
               "expr": "ceilometer_cpu{project=\"$projects\"}",
-              "format": "time_series",
-              "instant": false,
-              "intervalFactor": 1,
               "legendFormat": "{{resource}}",
               "refId": "A"
             }
@@ -1098,7 +1250,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 17
+            "y": 18
           },
           "id": 6,
           "panels": [],
@@ -1117,7 +1269,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 8,
@@ -1204,7 +1356,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 19
           },
           "hiddenSeries": false,
           "id": 10,
@@ -1291,7 +1443,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 11,
@@ -1378,7 +1530,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 9,
@@ -1465,7 +1617,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 12,
@@ -1553,7 +1705,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 13,
@@ -1640,7 +1792,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1728,7 +1880,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 15,
@@ -1802,9 +1954,1102 @@ spec:
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 39
+          },
+          "id": 34,
+          "panels": [],
+          "title": "Cloud Events",
+          "type": "row"
+        },
+        {
+          "columns": [
+            {
+              "text": "payload.generated",
+              "value": "payload.generated"
+            },
+            {
+              "text": "payload.event_type",
+              "value": "payload.event_type"
+            },
+            {
+              "text": "payload.traits.name",
+              "value": "payload.traits.name"
+            },
+            {
+              "text": "payload.traits.tenant_id",
+              "value": "payload.traits.tenant_id"
+            },
+            {
+              "text": "payload.traits.user_id",
+              "value": "payload.traits.user_id"
+            },
+            {
+              "text": "payload.traits.project_id",
+              "value": "payload.traits.project_id"
+            },
+            {
+              "text": "payload.traits.service",
+              "value": "payload.traits.service"
+            },
+            {
+              "text": "priority",
+              "value": "priority"
+            }
+          ],
+          "datasource": "es_ceilometer",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 40
+          },
+          "id": 35,
+          "options": {},
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "payload.generated",
+              "type": "date"
+            },
+            {
+              "alias": "Event",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.event_type",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Resource Name",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.name",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short",
+              "valueMaps": [
+                {
+                  "text": "-",
+                  "value": ""
+                }
+              ]
+            },
+            {
+              "alias": "Tenant ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.tenant_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "User ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.user_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Project ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.project_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.service",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Priority",
+              "colorMode": null,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "priority",
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                "0",
+                "1"
+              ],
+              "type": "string",
+              "unit": "short",
+              "valueMaps": []
+            }
+          ],
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "payload.traits.size",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_network_*",
+              "refId": "A",
+              "timeField": "payload.generated"
+            },
+            {
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "select field",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_subnet_*",
+              "refId": "C",
+              "timeField": "payload.generated"
+            },
+            {
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "select field",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_port_*",
+              "refId": "B",
+              "timeField": "payload.generated"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Networking",
+          "transform": "json",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "payload.generated",
+              "value": "payload.generated"
+            },
+            {
+              "text": "payload.event_type",
+              "value": "payload.event_type"
+            },
+            {
+              "text": "payload.traits.tenant_id",
+              "value": "payload.traits.tenant_id"
+            },
+            {
+              "text": "payload.traits.user_id",
+              "value": "payload.traits.user_id"
+            },
+            {
+              "text": "payload.traits.project_id",
+              "value": "payload.traits.project_id"
+            },
+            {
+              "text": "payload.traits.service",
+              "value": "payload.traits.service"
+            },
+            {
+              "text": "priority",
+              "value": "priority"
+            },
+            {
+              "text": "payload.traits.resource_id",
+              "value": "payload.traits.resource_id"
+            }
+          ],
+          "datasource": "es_ceilometer",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 46
+          },
+          "id": 36,
+          "options": {},
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "payload.generated",
+              "type": "date"
+            },
+            {
+              "alias": "Event",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.event_type",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Resource Name",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.resource_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Tenant ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.tenant_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "User ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.user_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Project ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.project_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.service",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Priority",
+              "colorMode": null,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "priority",
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                "0",
+                "1"
+              ],
+              "type": "string",
+              "unit": "short",
+              "valueMaps": []
+            }
+          ],
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "payload.traits.size",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_volume_*",
+              "refId": "A",
+              "timeField": "payload.generated"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Volumes",
+          "transform": "json",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "payload.generated",
+              "value": "payload.generated"
+            },
+            {
+              "text": "payload.event_type",
+              "value": "payload.event_type"
+            },
+            {
+              "text": "payload.traits.tenant_id",
+              "value": "payload.traits.tenant_id"
+            },
+            {
+              "text": "payload.traits.user_id",
+              "value": "payload.traits.user_id"
+            },
+            {
+              "text": "payload.traits.project_id",
+              "value": "payload.traits.project_id"
+            },
+            {
+              "text": "payload.traits.service",
+              "value": "payload.traits.service"
+            },
+            {
+              "text": "priority",
+              "value": "priority"
+            },
+            {
+              "text": "payload.traits.resource_id",
+              "value": "payload.traits.resource_id"
+            }
+          ],
+          "datasource": "es_ceilometer",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 51
+          },
+          "id": 37,
+          "options": {},
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "payload.generated",
+              "type": "date"
+            },
+            {
+              "alias": "Event",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.event_type",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Resource ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.resource_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Tenant ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.tenant_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "User ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.user_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Project ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.project_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.service",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Priority",
+              "colorMode": null,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "priority",
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                "0",
+                "1"
+              ],
+              "type": "string",
+              "unit": "short",
+              "valueMaps": []
+            }
+          ],
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "payload.traits.size",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_compute_*",
+              "refId": "A",
+              "timeField": "payload.generated"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Compute",
+          "transform": "json",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "payload.generated",
+              "value": "payload.generated"
+            },
+            {
+              "text": "payload.event_type",
+              "value": "payload.event_type"
+            },
+            {
+              "text": "payload.traits.service",
+              "value": "payload.traits.service"
+            },
+            {
+              "text": "priority",
+              "value": "priority"
+            },
+            {
+              "text": "payload.traits.resource_id",
+              "value": "payload.traits.resource_id"
+            }
+          ],
+          "datasource": "es_ceilometer",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 56
+          },
+          "id": 38,
+          "options": {},
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "payload.generated",
+              "type": "date"
+            },
+            {
+              "alias": "Event",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.event_type",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Resource ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.resource_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Tenant ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.tenant_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "User ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.user_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Project ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.project_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.service",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Priority",
+              "colorMode": null,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "priority",
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                "0",
+                "1"
+              ],
+              "type": "string",
+              "unit": "short",
+              "valueMaps": []
+            }
+          ],
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "payload.traits.size",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_identity_*",
+              "refId": "A",
+              "timeField": "payload.generated"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Identity",
+          "transform": "json",
+          "type": "table"
+        },
+        {
+          "columns": [
+            {
+              "text": "payload.generated",
+              "value": "payload.generated"
+            },
+            {
+              "text": "payload.event_type",
+              "value": "payload.event_type"
+            },
+            {
+              "text": "payload.traits.user_id",
+              "value": "payload.traits.user_id"
+            },
+            {
+              "text": "payload.traits.project_id",
+              "value": "payload.traits.project_id"
+            },
+            {
+              "text": "payload.traits.service",
+              "value": "payload.traits.service"
+            },
+            {
+              "text": "priority",
+              "value": "priority"
+            },
+            {
+              "text": "payload.traits.resource_id",
+              "value": "payload.traits.resource_id"
+            },
+            {
+              "text": "payload.traits.status",
+              "value": "payload.traits.status"
+            },
+            {
+              "text": "payload.traits.name",
+              "value": "payload.traits.name"
+            }
+          ],
+          "datasource": "es_ceilometer",
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 61
+          },
+          "id": 39,
+          "options": {},
+          "pageSize": null,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "alias": "Time",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "payload.generated",
+              "type": "date"
+            },
+            {
+              "alias": "Event",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.event_type",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Resource ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.resource_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Tenant ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.tenant_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "User ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.user_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Project ID",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.project_id",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Service",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.service",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Priority",
+              "colorMode": null,
+              "colors": [
+                "rgba(50, 172, 45, 0.97)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(245, 54, 54, 0.9)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "priority",
+              "preserveFormat": false,
+              "sanitize": false,
+              "thresholds": [
+                "0",
+                "1"
+              ],
+              "type": "string",
+              "unit": "short",
+              "valueMaps": []
+            },
+            {
+              "alias": "Status",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.status",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            },
+            {
+              "alias": "Name",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "payload.traits.name",
+              "thresholds": [],
+              "type": "number",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [],
+              "metrics": [
+                {
+                  "field": "payload.traits.size",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {
+                    "size": 500
+                  },
+                  "type": "raw_document"
+                }
+              ],
+              "query": "_index: ceilometer_image*",
+              "refId": "A",
+              "timeField": "payload.generated"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Images",
+          "transform": "json",
+          "type": "table"
         }
       ],
-      "refresh": "1m",
+      "refresh": "15m",
       "schemaVersion": 21,
       "style": "dark",
       "tags": [
@@ -1812,31 +3057,6 @@ spec:
       ],
       "templating": {
         "list": [
-          {
-            "allValue": null,
-            "current": {
-              "text": "13d97b93-63c6-4518-a885-05b95199ae9d",
-              "value": "13d97b93-63c6-4518-a885-05b95199ae9d"
-            },
-            "datasource": "STFPrometheus",
-            "definition": "label_values(ceilometer_cpu, resource)",
-            "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "instances",
-            "options": [],
-            "query": "label_values(ceilometer_cpu, resource)",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-          },
           {
             "allValue": null,
             "current": {
@@ -1867,7 +3087,7 @@ spec:
         ]
       },
       "time": {
-        "from": "now-6h",
+        "from": "now-12h",
         "to": "now"
       },
       "timepicker": {
@@ -1887,5 +3107,5 @@ spec:
       "timezone": "",
       "title": "Cloud View",
       "uid": "IHqhpjPZz",
-      "version": 86
+      "version": 53
     }

--- a/deploy/rhos-cloud-dashboard.yaml
+++ b/deploy/rhos-cloud-dashboard.yaml
@@ -6,6 +6,7 @@ metadata:
   name: rhos-cloud-dashboard
   namespace: service-telemetry
 spec:
+  name: rhos-cloud-dashboard.json
   plugins: 
     - name: grafana-polystat-panel
       version: "1.2.2"
@@ -20,7 +21,9 @@ spec:
             "enable": true,
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
+            "limit": 100,
             "name": "Annotations & Alerts",
+            "showIn": 0,
             "type": "dashboard"
           }
         ]
@@ -29,17 +32,228 @@ spec:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 2,
-      "links": [],
+      "iteration": 1606250232524,
+      "links": [
+        {
+          "asDropdown": true,
+          "icon": "external link",
+          "tags": [],
+          "type": "dashboards"
+        }
+      ],
       "panels": [
+        {
+          "cacheTimeout": null,
+          "cards": {
+            "cardPadding": 0,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#37872D",
+            "colorScale": "linear",
+            "colorScheme": "interpolateReds",
+            "exponent": 0.5,
+            "max": 1,
+            "min": 0,
+            "mode": "opacity"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "ceilometer_compute_instance",
+          "gridPos": {
+            "h": 7,
+            "w": 15,
+            "x": 0,
+            "y": 0
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 21,
+          "legend": {
+            "show": false
+          },
+          "links": [],
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "alias": "glance_api",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "2m",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:glance_api",
+              "refId": "B",
+              "timeField": "startsAt"
+            },
+            {
+              "alias": "nova_api",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "2m",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "pipelineVariables": [
+                    {
+                      "name": "",
+                      "pipelineAgg": "select metric"
+                    }
+                  ],
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:nova_api",
+              "refId": "A",
+              "timeField": "startsAt"
+            },
+            {
+              "alias": "heat_api",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "2m",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:heat_api",
+              "refId": "C",
+              "timeField": "startsAt"
+            },
+            {
+              "alias": "neutron_api",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "2m",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:neutron_api",
+              "refId": "D",
+              "timeField": "startsAt"
+            },
+            {
+              "alias": "placement_api",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "2m",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:placement_api",
+              "refId": "E",
+              "timeField": "startsAt"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "API Statuses",
+          "tooltip": {
+            "show": true,
+            "showHistogram": false
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": "2m",
+          "yAxis": {
+            "decimals": null,
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "middle",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
         {
           "dashboardFilter": "",
           "dashboardTags": [],
           "datasource": null,
           "folderId": null,
           "gridPos": {
-            "h": 13,
-            "w": 6,
-            "x": 18,
+            "h": 11,
+            "w": 9,
+            "x": 15,
             "y": 0
           },
           "id": 4,
@@ -52,8 +266,548 @@ spec:
           "stateFilter": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Alerts",
+          "title": "All Alerts",
           "type": "alertlist"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "ceilometer_compute_instance",
+          "decimals": null,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 0,
+            "y": 7
+          },
+          "id": 29,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:placement_api",
+              "refId": "A",
+              "timeField": "startsAt"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Uptime placement_api",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "ceilometer_compute_instance",
+          "decimals": null,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 3,
+            "y": 7
+          },
+          "id": 30,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:neutron_api",
+              "refId": "A",
+              "timeField": "startsAt"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Uptime neutron_api",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "ceilometer_compute_instance",
+          "decimals": null,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 6,
+            "y": 7
+          },
+          "id": 31,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:heat_api",
+              "refId": "A",
+              "timeField": "startsAt"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Uptime heat_api",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "ceilometer_compute_instance",
+          "decimals": null,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 9,
+            "y": 7
+          },
+          "id": 26,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:nova_api",
+              "refId": "A",
+              "timeField": "startsAt"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Uptime nova_api",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+          ],
+          "datasource": "ceilometer_compute_instance",
+          "decimals": null,
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 12,
+            "y": 7
+          },
+          "id": 32,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "options": {},
+          "pluginVersion": "6.5.1",
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false,
+            "ymax": null,
+            "ymin": null
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "alias": "",
+              "bucketAggs": [
+                {
+                  "field": "startsAt",
+                  "id": "2",
+                  "settings": {
+                    "interval": "auto",
+                    "min_doc_count": 0,
+                    "trimEdges": 0
+                  },
+                  "type": "date_histogram"
+                }
+              ],
+              "metrics": [
+                {
+                  "field": "annotations.output.healthy",
+                  "id": "1",
+                  "meta": {},
+                  "settings": {},
+                  "type": "avg"
+                }
+              ],
+              "query": "annotations.output.service:glance_api",
+              "refId": "A",
+              "timeField": "startsAt"
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Uptime glance_api",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
         },
         {
           "collapsed": false,
@@ -62,11 +816,293 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 13
+            "y": 11
+          },
+          "id": 23,
+          "panels": [],
+          "title": "Instances",
+          "type": "row"
+        },
+        {
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a",
+            "#4040a0"
+          ],
+          "datasource": null,
+          "description": "Click instance for drill down view",
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 17,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxPerRow": 3,
+          "options": {},
+          "polystat": {
+            "animationSpeed": 2500,
+            "columnAutoSize": true,
+            "columns": "",
+            "defaultClickThrough": "",
+            "defaultClickThroughNewTab": false,
+            "defaultClickThroughSanitize": false,
+            "displayLimit": 100,
+            "fontAutoColor": true,
+            "fontAutoScale": true,
+            "fontColor": "",
+            "fontSize": 12,
+            "fontType": "Roboto",
+            "globalDecimals": 2,
+            "globalDisplayMode": "all",
+            "globalDisplayTextTriggeredEmpty": "OK",
+            "globalOperatorName": "avg",
+            "globalUnitFormat": "short",
+            "gradientEnabled": false,
+            "hexagonSortByDirection": 1,
+            "hexagonSortByField": "name",
+            "maxMetrics": 0,
+            "polygonBorderColor": "black",
+            "polygonBorderSize": 2,
+            "polygonGlobalFillColor": "#FFEE52",
+            "radius": "",
+            "radiusAutoSize": true,
+            "rowAutoSize": true,
+            "rows": "",
+            "shape": "hexagon_pointed_top",
+            "tooltipDisplayMode": "all",
+            "tooltipDisplayTextTriggeredEmpty": "OK",
+            "tooltipFontSize": 12,
+            "tooltipFontType": "Roboto",
+            "tooltipPrimarySortDirection": 2,
+            "tooltipPrimarySortField": "thresholdLevel",
+            "tooltipSecondarySortDirection": 2,
+            "tooltipSecondarySortField": "value",
+            "tooltipTimestampEnabled": true,
+            "valueEnabled": false
+          },
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": "projects",
+          "repeatDirection": "h",
+          "savedComposites": [],
+          "savedOverrides": [
+            {
+              "clickThrough": "d/hvMzdgdMz/virtual-machine-view?var-project=${projects}",
+              "colors": [
+                "#299c46",
+                "#e5ac0e",
+                "#bf1b00",
+                "#4040a0"
+              ],
+              "decimals": "",
+              "enabled": true,
+              "label": "OVERRIDE 1",
+              "metricName": ".*",
+              "newTabEnabled": true,
+              "operatorName": "avg",
+              "prefix": "",
+              "sanitizeURLEnabled": true,
+              "scaledDecimals": null,
+              "suffix": "",
+              "thresholds": [],
+              "unitFormat": "short"
+            }
+          ],
+          "scopedVars": {
+            "projects": {
+              "selected": false,
+              "text": "40390761eaf7414c8125917efc21024c",
+              "value": "40390761eaf7414c8125917efc21024c"
+            }
+          },
+          "targets": [
+            {
+              "expr": "ceilometer_cpu{project=\"$projects\"}",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{resource}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Project $projects",
+          "type": "grafana-polystat-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ]
+        },
+        {
+          "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a",
+            "#4040a0"
+          ],
+          "datasource": null,
+          "description": "Click instance for drill down view",
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 28,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxPerRow": 3,
+          "options": {},
+          "polystat": {
+            "animationSpeed": 2500,
+            "columnAutoSize": true,
+            "columns": "",
+            "defaultClickThrough": "",
+            "defaultClickThroughNewTab": false,
+            "defaultClickThroughSanitize": false,
+            "displayLimit": 100,
+            "fontAutoColor": true,
+            "fontAutoScale": true,
+            "fontColor": "",
+            "fontSize": 12,
+            "fontType": "Roboto",
+            "globalDecimals": 2,
+            "globalDisplayMode": "all",
+            "globalDisplayTextTriggeredEmpty": "OK",
+            "globalOperatorName": "avg",
+            "globalUnitFormat": "short",
+            "gradientEnabled": false,
+            "hexagonSortByDirection": 1,
+            "hexagonSortByField": "name",
+            "maxMetrics": 0,
+            "polygonBorderColor": "black",
+            "polygonBorderSize": 2,
+            "polygonGlobalFillColor": "#FFEE52",
+            "radius": "",
+            "radiusAutoSize": true,
+            "rowAutoSize": true,
+            "rows": "",
+            "shape": "hexagon_pointed_top",
+            "tooltipDisplayMode": "all",
+            "tooltipDisplayTextTriggeredEmpty": "OK",
+            "tooltipFontSize": 12,
+            "tooltipFontType": "Roboto",
+            "tooltipPrimarySortDirection": 2,
+            "tooltipPrimarySortField": "thresholdLevel",
+            "tooltipSecondarySortDirection": 2,
+            "tooltipSecondarySortField": "value",
+            "tooltipTimestampEnabled": true,
+            "valueEnabled": false
+          },
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "repeat": null,
+          "repeatDirection": "h",
+          "repeatIteration": 1606250232524,
+          "repeatPanelId": 17,
+          "savedComposites": [],
+          "savedOverrides": [
+            {
+              "clickThrough": "d/hvMzdgdMz/virtual-machine-view?var-project=${projects}",
+              "colors": [
+                "#299c46",
+                "#e5ac0e",
+                "#bf1b00",
+                "#4040a0"
+              ],
+              "decimals": "",
+              "enabled": true,
+              "label": "OVERRIDE 1",
+              "metricName": ".*",
+              "newTabEnabled": true,
+              "operatorName": "avg",
+              "prefix": "",
+              "sanitizeURLEnabled": true,
+              "scaledDecimals": null,
+              "suffix": "",
+              "thresholds": [],
+              "unitFormat": "short"
+            }
+          ],
+          "scopedVars": {
+            "projects": {
+              "selected": false,
+              "text": "e336c69fda3a4044aa55db034fb8a0b3",
+              "value": "e336c69fda3a4044aa55db034fb8a0b3"
+            }
+          },
+          "targets": [
+            {
+              "expr": "ceilometer_cpu{project=\"$projects\"}",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{resource}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Project $projects",
+          "type": "grafana-polystat-panel",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ]
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 17
           },
           "id": 6,
           "panels": [],
-          "title": "Services",
+          "title": "Service Resource Usage",
           "type": "row"
         },
         {
@@ -81,7 +1117,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 8,
@@ -168,7 +1204,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 18
           },
           "hiddenSeries": false,
           "id": 10,
@@ -255,7 +1291,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 11,
@@ -342,7 +1378,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 9,
@@ -429,7 +1465,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 12,
@@ -517,7 +1553,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 13,
@@ -604,7 +1640,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 14,
@@ -692,7 +1728,7 @@ spec:
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 33
           },
           "hiddenSeries": false,
           "id": 15,
@@ -768,14 +1804,67 @@ spec:
           }
         }
       ],
-      "refresh": "",
+      "refresh": "1m",
       "schemaVersion": 21,
       "style": "dark",
       "tags": [
         "CloudView"
       ],
       "templating": {
-        "list": []
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "text": "13d97b93-63c6-4518-a885-05b95199ae9d",
+              "value": "13d97b93-63c6-4518-a885-05b95199ae9d"
+            },
+            "datasource": "STFPrometheus",
+            "definition": "label_values(ceilometer_cpu, resource)",
+            "hide": 2,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "instances",
+            "options": [],
+            "query": "label_values(ceilometer_cpu, resource)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "text": "All",
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": "STFPrometheus",
+            "definition": "label_values(ceilometer_cpu,project)",
+            "hide": 2,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "projects",
+            "options": [],
+            "query": "label_values(ceilometer_cpu,project)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
       },
       "time": {
         "from": "now-6h",
@@ -798,5 +1887,5 @@ spec:
       "timezone": "",
       "title": "Cloud View",
       "uid": "IHqhpjPZz",
-      "version": 17
+      "version": 86
     }

--- a/deploy/rhos-cloud-dashboard.yaml
+++ b/deploy/rhos-cloud-dashboard.yaml
@@ -9,6 +9,7 @@ spec:
   plugins: 
     - name: grafana-polystat-panel
       version: "1.2.2"
+  name: rhos-cloud-dashboard.json
   json: |
     {
       "annotations": {
@@ -36,9 +37,9 @@ spec:
           "datasource": null,
           "folderId": null,
           "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
+            "h": 13,
+            "w": 6,
+            "x": 18,
             "y": 0
           },
           "id": 4,
@@ -55,401 +56,17 @@ spec:
           "type": "alertlist"
         },
         {
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": null,
-          "gridPos": {
-            "h": 23,
-            "w": 24,
-            "x": 0,
-            "y": 9
-          },
-          "id": 2,
-          "options": {},
-          "polystat": {
-            "animationSpeed": 2500,
-            "columnAutoSize": true,
-            "columns": 1,
-            "defaultClickThrough": "http://grafana-sa-telemetry.apps-crc.testing/d/1F1OJZEWz/infrastructure-skeleton?var-hosts=${__cell_name}",
-            "defaultClickThroughSanitize": false,
-            "displayLimit": 1000,
-            "fontAutoScale": false,
-            "fontSize": 10,
-            "fontType": "Roboto",
-            "globalDecimals": null,
-            "globalDisplayMode": "all",
-            "globalDisplayTextTriggeredEmpty": "OK",
-            "globalOperatorName": "current",
-            "globalUnitFormat": "none",
-            "gradientEnabled": true,
-            "hexagonSortByDirection": "asc",
-            "hexagonSortByField": "name",
-            "maxMetrics": 0,
-            "polygonBorderColor": "black",
-            "polygonBorderSize": 2,
-            "polygonGlobalFillColor": "#C4162A",
-            "radius": 25,
-            "radiusAutoSize": true,
-            "rowAutoSize": true,
-            "rows": "",
-            "shape": "hexagon_pointed_top",
-            "tooltipDisplayMode": "all",
-            "tooltipDisplayTextTriggeredEmpty": "OK",
-            "tooltipFontSize": 12,
-            "tooltipFontType": "Roboto",
-            "tooltipPrimarySortDirection": "desc",
-            "tooltipPrimarySortField": "name",
-            "tooltipSecondarySortDirection": "desc",
-            "tooltipSecondarySortField": "value",
-            "tooltipTimestampEnabled": true
-          },
-          "savedComposites": [],
-          "savedOverrides": [
-            {
-              "clickThrough": "",
-              "colors": [
-                "#299c46",
-                "#e5ac0e",
-                "#bf1b00",
-                "#ffffff"
-              ],
-              "decimals": "",
-              "enabled": true,
-              "label": "OVERRIDE 1",
-              "metricName": ".*",
-              "operatorName": "current",
-              "prefix": "",
-              "sanitizeURLEnabled": true,
-              "scaledDecimals": null,
-              "suffix": "",
-              "thresholds": [
-                {
-                  "color": "#C4162A",
-                  "state": 1,
-                  "value": 0
-                },
-                {
-                  "color": "#299c46",
-                  "state": 0,
-                  "value": 1
-                }
-              ],
-              "unitFormat": "none"
-            }
-          ],
-          "targets": [
-            {
-              "expr": "collectd_last_metric_for_host_status",
-              "format": "time_series",
-              "instant": false,
-              "legendFormat": "{{host}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Cloud Nodes",
-          "type": "grafana-polystat-panel"
-        },
-        {
-          "collapsed": true,
-          "datasource": null,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 32
-          },
-          "id": 11,
-          "panels": [
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": null,
-              "fill": 1,
-              "fillGradient": 0,
-              "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 33
-              },
-              "hiddenSeries": false,
-              "id": 7,
-              "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": true
-              },
-              "lines": true,
-              "linewidth": 1,
-              "nullPointMode": "null",
-              "options": {
-                "dataLinks": []
-              },
-              "percentage": false,
-              "pointradius": 2,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (host) (collectd_cpu_percent{type_instance!=\"idle\",host=~\"controller.*\"}) / count by (host) (sum by (plugin_instance,host) (collectd_cpu_percent{type_instance!=\"idle\",host=~\"controller.*\"}))",
-                  "legendFormat": "{{host}}",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "CPU Usage",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "percent",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": null,
-              "decimals": 2,
-              "fill": 1,
-              "fillGradient": 0,
-              "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 39
-              },
-              "hiddenSeries": false,
-              "id": 13,
-              "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": true
-              },
-              "lines": true,
-              "linewidth": 1,
-              "nullPointMode": "null",
-              "options": {
-                "dataLinks": []
-              },
-              "percentage": false,
-              "pointradius": 2,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (host) (collectd_memory{plugin_instance=\"used\",host=~\"controller.*\"})",
-                  "legendFormat": "{{host}}",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Memory Usage",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "bytes",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "short",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": false
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            },
-            {
-              "aliasColors": {},
-              "bars": false,
-              "dashLength": 10,
-              "dashes": false,
-              "datasource": null,
-              "decimals": 2,
-              "fill": 1,
-              "fillGradient": 0,
-              "gridPos": {
-                "h": 6,
-                "w": 24,
-                "x": 0,
-                "y": 45
-              },
-              "hiddenSeries": false,
-              "id": 12,
-              "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "total": false,
-                "values": true
-              },
-              "lines": true,
-              "linewidth": 1,
-              "nullPointMode": "null",
-              "options": {
-                "dataLinks": []
-              },
-              "percentage": false,
-              "pointradius": 2,
-              "points": false,
-              "renderer": "flot",
-              "seriesOverrides": [],
-              "spaceLength": 10,
-              "stack": false,
-              "steppedLine": false,
-              "targets": [
-                {
-                  "expr": "sum by (host) (collectd_df_df_complex{plugin_instance!~\"devtmpfs|overlay|shm|tmpfs\",type_instance!~\"free\", host=~\"controller.*\"})",
-                  "legendFormat": "{{host}}",
-                  "refId": "A"
-                }
-              ],
-              "thresholds": [],
-              "timeFrom": null,
-              "timeRegions": [],
-              "timeShift": null,
-              "title": "Disk Usage",
-              "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-              },
-              "type": "graph",
-              "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": []
-              },
-              "yaxes": [
-                {
-                  "format": "bytes",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                },
-                {
-                  "format": "bytes",
-                  "label": null,
-                  "logBase": 1,
-                  "max": null,
-                  "min": null,
-                  "show": true
-                }
-              ],
-              "yaxis": {
-                "align": false,
-                "alignLevel": null
-              }
-            }
-          ],
-          "title": "Controller Nodes",
-          "type": "row"
-        },
-        {
           "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 13
           },
-          "id": 9,
+          "id": 6,
           "panels": [],
-          "title": "Compute Nodes",
+          "title": "Services",
           "type": "row"
         },
         {
@@ -461,23 +78,21 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 6,
-            "w": 24,
+            "h": 5,
+            "w": 12,
             "x": 0,
-            "y": 34
+            "y": 14
           },
           "hiddenSeries": false,
-          "id": 14,
+          "id": 8,
           "legend": {
-            "alignAsTable": true,
             "avg": false,
-            "current": true,
-            "max": true,
-            "min": true,
-            "rightSide": true,
+            "current": false,
+            "max": false,
+            "min": false,
             "show": true,
             "total": false,
-            "values": true
+            "values": false
           },
           "lines": true,
           "linewidth": 1,
@@ -495,7 +110,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (host) (collectd_cpu_percent{type_instance!=\"idle\",host=~\"compute.*\"}) / count by (host) (sum by (cpu,host) (collectd_cpu_percent{type_instance!=\"idle\",host=~\"compute.*\"}))",
+              "expr": "collectd_libpodstats_pod_cpu_percent{plugin_instance=\"horizon\"}",
               "legendFormat": "{{host}}",
               "refId": "A"
             }
@@ -504,7 +119,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "CPU Usage",
+          "title": "Horizon CPU Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -528,12 +143,623 @@ spec:
               "show": true
             },
             {
-              "format": "short",
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "collectd_libpodstats_pod_memory{plugin_instance=\"horizon\"}",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Horizon Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
               "label": null,
               "logBase": 1,
               "max": null,
               "min": null,
               "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (host) (collectd_libpodstats_pod_cpu_percent{plugin_instance=~\"ceph-.*\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Ceph CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 9,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (host) (collectd_libpodstats_pod_memory{plugin_instance=~\"ceph-.*\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Ceph Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 12,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (host) (collectd_libpodstats_pod_cpu_percent{plugin_instance=~\"nova.*\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Nova CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (host) (collectd_libpodstats_pod_memory{plugin_instance=~\"nova.*\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Nova Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 14,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (host) (collectd_libpodstats_pod_cpu_percent{plugin_instance=~\"ceilometer.*\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Ceilometer CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 15,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (host) (collectd_libpodstats_pod_memory{plugin_instance=~\"ceilometer.*\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Ceilometer Memory Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
             }
           ],
           "yaxis": {
@@ -572,6 +798,5 @@ spec:
       "timezone": "",
       "title": "Cloud View",
       "uid": "IHqhpjPZz",
-      "version": 19
+      "version": 17
     }
-  name: rhos-cloud-dashboard.json

--- a/deploy/rhos-cloud-dashboard.yaml
+++ b/deploy/rhos-cloud-dashboard.yaml
@@ -29,7 +29,7 @@ spec:
           {
             "datasource": "es_ceilometer",
             "enable": true,
-            "hide": false,
+            "hide": true,
             "iconColor": "rgba(255, 96, 96, 1)",
             "limit": 100,
             "name": "volume_alert",
@@ -47,7 +47,7 @@ spec:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 1,
-      "iteration": 1606335117051,
+      "iteration": 1606748274752,
       "links": [],
       "panels": [
         {
@@ -294,7 +294,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(3, sum by (plugin_instance, host) (collectd_libpodstats_pod_memory))",
+              "expr": "topk($top, sum by (plugin_instance, host) (collectd_libpodstats_pod_memory))",
               "legendFormat": "{{plugin_instance}} on {{host}}",
               "refId": "A"
             }
@@ -303,7 +303,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Top 3 Memory Consumers",
+          "title": "Top $top Memory Consumers",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -381,7 +381,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(3, avg_over_time(collectd_libpodstats_pod_cpu_percent[10m]))",
+              "expr": "topk($top, avg_over_time(collectd_libpodstats_pod_cpu_percent[10m]))",
               "legendFormat": "{{plugin_instance}} on {{host}}",
               "refId": "A"
             }
@@ -390,7 +390,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Top 3 CPU Consumers",
+          "title": "Top $top CPU Consumers",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1157,7 +1157,7 @@ spec:
             "globalDecimals": 2,
             "globalDisplayMode": "all",
             "globalDisplayTextTriggeredEmpty": "OK",
-            "globalOperatorName": "avg",
+            "globalOperatorName": "current",
             "globalUnitFormat": "short",
             "gradientEnabled": false,
             "hexagonSortByDirection": 1,
@@ -1191,7 +1191,7 @@ spec:
           ],
           "repeat": null,
           "repeatDirection": "h",
-          "repeatIteration": 1606335117051,
+          "repeatIteration": 1606748274752,
           "repeatPanelId": 17,
           "savedComposites": [],
           "savedOverrides": [
@@ -3083,11 +3083,130 @@ spec:
             "tagsQuery": "",
             "type": "query",
             "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "tags": [],
+              "text": "8",
+              "value": "8"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "top",
+            "options": [
+              {
+                "selected": false,
+                "text": "1",
+                "value": "1"
+              },
+              {
+                "selected": false,
+                "text": "2",
+                "value": "2"
+              },
+              {
+                "selected": false,
+                "text": "3",
+                "value": "3"
+              },
+              {
+                "selected": false,
+                "text": "4",
+                "value": "4"
+              },
+              {
+                "selected": false,
+                "text": "5",
+                "value": "5"
+              },
+              {
+                "selected": false,
+                "text": "6",
+                "value": "6"
+              },
+              {
+                "selected": false,
+                "text": "7",
+                "value": "7"
+              },
+              {
+                "selected": true,
+                "text": "8",
+                "value": "8"
+              },
+              {
+                "selected": false,
+                "text": "9",
+                "value": "9"
+              },
+              {
+                "selected": false,
+                "text": "10",
+                "value": "10"
+              },
+              {
+                "selected": false,
+                "text": "11",
+                "value": "11"
+              },
+              {
+                "selected": false,
+                "text": "12",
+                "value": "12"
+              },
+              {
+                "selected": false,
+                "text": "13",
+                "value": "13"
+              },
+              {
+                "selected": false,
+                "text": "14",
+                "value": "14"
+              },
+              {
+                "selected": false,
+                "text": "15",
+                "value": "15"
+              },
+              {
+                "selected": false,
+                "text": "16",
+                "value": "16"
+              },
+              {
+                "selected": false,
+                "text": "17",
+                "value": "17"
+              },
+              {
+                "selected": false,
+                "text": "18",
+                "value": "18"
+              },
+              {
+                "selected": false,
+                "text": "19",
+                "value": "19"
+              },
+              {
+                "selected": false,
+                "text": "20",
+                "value": "20"
+              }
+            ],
+            "query": "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20",
+            "skipUrlSync": false,
+            "type": "custom"
           }
         ]
       },
       "time": {
-        "from": "now-12h",
+        "from": "now-6h",
         "to": "now"
       },
       "timepicker": {
@@ -3107,5 +3226,5 @@ spec:
       "timezone": "",
       "title": "Cloud View",
       "uid": "IHqhpjPZz",
-      "version": 53
+      "version": 62
     }


### PR DESCRIPTION
Cloud dashboard updates:

**Top**
API Uptime heat map - shows time that OSP APIs are healthy
API Uptime % panels - shows percentage of time in the current time interval that the each API has been healthy
Top 3 consumer panels: shows top 3 memory and cpu consumers on each node

**Instances**
Separate polystat panels are generated for each project and the running instances populated. Clicking on the instances (hexagons) drills down to the VM view dashboard

**Service Resource Usage**
Shows CPU and Memory that each openstack service is consuming on each node

**Cloud Events**
Sections out events according to resource type. These come from ceilometer

Additionally, there are annotations for when volume events happen

![image](https://user-images.githubusercontent.com/41337120/100280261-e06dda80-2f35-11eb-8a12-adc6fa49941d.png)
