### PR TITLE
Adjust host filter to populate on one collectd metric

### DIFF
--- a/deploy/rhos-dashboard.yaml
+++ b/deploy/rhos-dashboard.yaml
@@ -24,13 +24,17 @@ spec:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 1,
-      "iteration": 1606152811123,
+      "id": 2,
+      "iteration": 1625857489667,
       "links": [],
       "panels": [
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -56,7 +60,6 @@ spec:
           },
           "id": 61,
           "links": [],
-          "options": {},
           "pageSize": null,
           "pluginVersion": "6.5.1",
           "showHeader": true,
@@ -67,6 +70,7 @@ spec:
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "link": false,
               "pattern": "Time",
@@ -74,6 +78,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -115,6 +120,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -131,6 +137,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -147,6 +154,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -175,7 +183,7 @@ spec:
           "timeShift": null,
           "title": "Current Global Alerts",
           "transform": "table",
-          "type": "table"
+          "type": "table-old"
         },
         {
           "cacheTimeout": null,
@@ -191,7 +199,6 @@ spec:
           },
           "id": 62,
           "links": [],
-          "options": {},
           "pageSize": null,
           "pluginVersion": "6.5.1",
           "showHeader": true,
@@ -202,6 +209,7 @@ spec:
           "styles": [
             {
               "alias": "Time",
+              "align": "auto",
               "dateFormat": "YYYY-MM-DD HH:mm:ss",
               "link": false,
               "pattern": "Time",
@@ -209,6 +217,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": "cell",
               "colors": [
                 "rgba(50, 172, 45, 0.97)",
@@ -250,6 +259,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -266,6 +276,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -282,6 +293,7 @@ spec:
             },
             {
               "alias": "",
+              "align": "auto",
               "colorMode": null,
               "colors": [
                 "rgba(245, 54, 54, 0.9)",
@@ -310,11 +322,15 @@ spec:
           "timeShift": null,
           "title": "Recent Global Alerts",
           "transform": "table",
-          "type": "table"
+          "type": "table-old"
         },
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -328,24 +344,46 @@ spec:
         },
         {
           "cacheTimeout": null,
-          "colorBackground": true,
-          "colorPostfix": false,
-          "colorPrefix": false,
-          "colorValue": false,
-          "colors": [
-            "#37872D",
-            "#C4162A",
-            "#C4162A"
-          ],
           "datasource": "STFPrometheus",
           "description": "",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "text": "Node Active"
+                    },
+                    "1": {
+                      "text": "Node Inactive"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#37872D",
+                    "value": null
+                  },
+                  {
+                    "color": "#C4162A",
+                    "value": 1
+                  },
+                  {
+                    "color": "#C4162A",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
           },
           "gridPos": {
             "h": 5,
@@ -356,39 +394,23 @@ spec:
           "id": 33,
           "interval": null,
           "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
           "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
           },
-          "tableColumn": "",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "absent({host = '$hosts'}) or label_replace(vector(0), \"host\", \"$hosts\", \"host\", \".*\")",
@@ -398,44 +420,46 @@ spec:
               "refId": "B"
             }
           ],
-          "thresholds": "1,1",
           "timeFrom": null,
           "timeShift": null,
-          "title": "",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "Node Active",
-              "value": "0"
-            },
-            {
-              "op": "=",
-              "text": "Node Inactive",
-              "value": "1"
-            }
-          ],
-          "valueName": "current"
+          "type": "stat"
         },
         {
           "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
           "datasource": "STFPrometheus",
           "description": "Time node has been operational",
-          "format": "dtdurations",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "dtdurations"
+            },
+            "overrides": []
           },
           "gridPos": {
             "h": 5,
@@ -446,39 +470,23 @@ spec:
           "id": 31,
           "interval": null,
           "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
           "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
           },
-          "tableColumn": "",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "collectd_uptime{host=\"$hosts\"}",
@@ -487,25 +495,48 @@ spec:
               "refId": "A"
             }
           ],
-          "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
           "title": "Uptime",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
+          "type": "stat"
         },
         {
           "cacheTimeout": null,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "id": 0,
+                  "op": "=",
+                  "text": "0.0%",
+                  "type": 1,
+                  "value": "null"
+                }
+              ],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#299c46",
+                    "value": null
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 5,
             "w": 3,
@@ -515,43 +546,19 @@ spec:
           "id": 19,
           "links": [],
           "options": {
-            "fieldOptions": {
+            "orientation": "horizontal",
+            "reduceOptions": {
               "calcs": [
                 "last"
               ],
-              "defaults": {
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "0.0%",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 100,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "#299c46",
-                    "value": null
-                  },
-                  {
-                    "color": "#d44a3a",
-                    "value": 80
-                  }
-                ],
-                "unit": "percent"
-              },
-              "override": {},
+              "fields": "",
               "values": false
             },
-            "orientation": "horizontal",
             "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "showThresholdMarkers": true,
+            "text": {}
           },
-          "pluginVersion": "6.5.1",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "sum(collectd_cpu_percent{type_instance!=\"idle\", host=\"$hosts\"}) / count(sum by (type_instance) (collectd_cpu_percent{type_instance!=\"idle\",host=\"$hosts\"}))",
@@ -571,6 +578,40 @@ spec:
           "cacheTimeout": null,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "mappings": [
+                {
+                  "id": 0,
+                  "op": "=",
+                  "text": "0.0%",
+                  "type": 1,
+                  "value": "null"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#299c46",
+                    "value": null
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 0.8
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 5,
             "w": 3,
@@ -580,44 +621,19 @@ spec:
           "id": 44,
           "links": [],
           "options": {
-            "fieldOptions": {
+            "orientation": "horizontal",
+            "reduceOptions": {
               "calcs": [
                 "last"
               ],
-              "defaults": {
-                "decimals": 1,
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "0.0%",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 1,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "#299c46",
-                    "value": null
-                  },
-                  {
-                    "color": "#d44a3a",
-                    "value": 0.8
-                  }
-                ],
-                "unit": "percentunit"
-              },
-              "override": {},
+              "fields": "",
               "values": false
             },
-            "orientation": "horizontal",
             "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "showThresholdMarkers": true,
+            "text": {}
           },
-          "pluginVersion": "6.5.1",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "sum(collectd_memory{type_instance=\"used\",host=\"$hosts\"})/ sum(collectd_memory{host=\"$hosts\"})",
@@ -637,6 +653,40 @@ spec:
           "cacheTimeout": null,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "id": 0,
+                  "op": "=",
+                  "text": "N/A",
+                  "type": 1,
+                  "value": "null"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 5,
             "w": 3,
@@ -647,42 +697,18 @@ spec:
           "links": [],
           "options": {
             "displayMode": "gradient",
-            "fieldOptions": {
+            "orientation": "horizontal",
+            "reduceOptions": {
               "calcs": [
                 "lastNotNull"
               ],
-              "defaults": {
-                "decimals": 0,
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "N/A",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 1,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ],
-                "unit": "percentunit"
-              },
-              "override": {},
+              "fields": "",
               "values": false
             },
-            "orientation": "horizontal"
+            "showUnfilled": true,
+            "text": {}
           },
-          "pluginVersion": "6.5.1",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "sum(collectd_df_df_complex{host=\"$hosts\",type_instance=\"used\"}) by (plugin_instance) / sum(collectd_df_df_complex{host=\"$hosts\"}) by (plugin_instance)",
@@ -701,22 +727,40 @@ spec:
         },
         {
           "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
           "datasource": "STFPrometheus",
           "description": "",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
           },
           "gridPos": {
             "h": 5,
@@ -727,41 +771,23 @@ spec:
           "id": 54,
           "interval": null,
           "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
           "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
+          "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "delta"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
           },
-          "tableColumn": "",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "sum(collectd_interface_if_errors_rx_total{host=\"$hosts\"}) + sum(collectd_interface_if_errors_tx_total{host=\"$hosts\"})",
@@ -771,20 +797,10 @@ spec:
               "refId": "A"
             }
           ],
-          "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
           "title": "Interface Errors",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "delta"
+          "type": "stat"
         },
         {
           "aliasColors": {},
@@ -793,6 +809,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "Load average represents the average number of running and un-interruptable processes residing in the kernel's execution queue. \n\nTypically, short term, midterm, and long term series give running averages of 1m, 5m, and 15m, respectively. ",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -817,9 +839,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -895,6 +918,10 @@ spec:
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -913,6 +940,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -939,9 +972,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1014,6 +1048,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1040,9 +1080,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1117,6 +1158,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1143,9 +1190,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1216,6 +1264,10 @@ spec:
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1234,6 +1286,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "Average non-idle CPU activity of all cores on node",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1260,9 +1318,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1327,6 +1386,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "Shows average time spent for each activity across all cores",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1353,9 +1418,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1417,6 +1483,10 @@ spec:
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1436,6 +1506,12 @@ spec:
           "datasource": "STFPrometheus",
           "decimals": null,
           "description": "Memory used on node",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1462,9 +1538,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1529,6 +1606,12 @@ spec:
           "dashLength": 10,
           "dashes": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1553,10 +1636,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "6.5.2",
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1617,6 +1700,39 @@ spec:
         {
           "cacheTimeout": null,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "id": 0,
+                  "op": "=",
+                  "text": "0.0%",
+                  "type": 1,
+                  "value": "null"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 5,
             "w": 3,
@@ -1626,43 +1742,19 @@ spec:
           "id": 71,
           "links": [],
           "options": {
-            "fieldOptions": {
+            "orientation": "horizontal",
+            "reduceOptions": {
               "calcs": [
                 "last"
               ],
-              "defaults": {
-                "mappings": [
-                  {
-                    "id": 0,
-                    "op": "=",
-                    "text": "0.0%",
-                    "type": 1,
-                    "value": "null"
-                  }
-                ],
-                "max": 1,
-                "min": 0,
-                "nullValueMode": "connected",
-                "thresholds": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 0.8
-                  }
-                ],
-                "unit": "percentunit"
-              },
-              "override": {},
+              "fields": "",
               "values": false
             },
-            "orientation": "horizontal",
             "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "showThresholdMarkers": true,
+            "text": {}
           },
-          "pluginVersion": "6.5.1",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "sum(collectd_hugepages_vmpage_number{type_instance=\"used\",host=\"$hosts\"}) / sum(collectd_hugepages_vmpage_number{host=\"$hosts\"})",
@@ -1680,6 +1772,10 @@ spec:
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1695,6 +1791,32 @@ spec:
           "cacheTimeout": null,
           "datasource": "STFPrometheus",
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
           "gridPos": {
             "h": 8,
             "w": 6,
@@ -1705,33 +1827,18 @@ spec:
           "links": [],
           "options": {
             "displayMode": "gradient",
-            "fieldOptions": {
+            "orientation": "horizontal",
+            "reduceOptions": {
               "calcs": [
                 "last"
               ],
-              "defaults": {
-                "decimals": 2,
-                "mappings": [],
-                "max": 1,
-                "min": 0,
-                "thresholds": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ],
-                "unit": "percentunit"
-              },
-              "override": {},
+              "fields": "",
               "values": false
             },
-            "orientation": "horizontal"
+            "showUnfilled": true,
+            "text": {}
           },
-          "pluginVersion": "6.5.1",
+          "pluginVersion": "8.0.4",
           "targets": [
             {
               "expr": "sum by (plugin_instance) (collectd_df_df_inodes{type_instance=\"used\", host=\"$hosts\"}) / sum by (plugin_instance) (collectd_df_df_inodes{host=\"$hosts\"})",
@@ -1752,6 +1859,12 @@ spec:
           "dashLength": 10,
           "dashes": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1778,9 +1891,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1841,6 +1955,10 @@ spec:
         {
           "collapsed": false,
           "datasource": "STFPrometheus",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1860,6 +1978,12 @@ spec:
           "datasource": "STFPrometheus",
           "decimals": 2,
           "description": "10m rolling average",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1887,9 +2011,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1963,6 +2088,12 @@ spec:
           "datasource": "STFPrometheus",
           "decimals": 2,
           "description": "Approximate percentage of total disk bandwidth being used.\n\nWeighted I/O includes the backlog that may be accumulating.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -1989,9 +2120,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2064,6 +2196,12 @@ spec:
           "datasource": "STFPrometheus",
           "decimals": null,
           "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2090,9 +2228,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2166,6 +2305,12 @@ spec:
           "dashes": false,
           "datasource": "STFPrometheus",
           "description": "Average time each I/O operation took to complete. Per the collectd disk plugin docs (https://collectd.org/wiki/index.php/Plugin:Disk), this average is not very accurate.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
@@ -2192,9 +2337,10 @@ spec:
           "links": [],
           "nullPointMode": "null",
           "options": {
-            "dataLinks": []
+            "alertThreshold": true
           },
           "percentage": false,
+          "pluginVersion": "8.0.4",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2263,28 +2409,37 @@ spec:
         }
       ],
       "refresh": "1m",
-      "schemaVersion": 21,
+      "schemaVersion": 30,
       "style": "dark",
       "tags": [],
       "templating": {
         "list": [
           {
             "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "ceph-0.osp-cloudops-01",
+              "value": "ceph-0.osp-cloudops-01"
+            },
             "datasource": "STFPrometheus",
-            "definition": "label_values(host)",
+            "definition": "label_values(collectd_cpu_percent, host)",
+            "description": null,
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "nodes",
             "multi": false,
             "name": "hosts",
             "options": [],
-            "query": "label_values(host)",
+            "query": {
+              "query": "label_values(collectd_cpu_percent, host)",
+              "refId": "StandardVariableQuery"
+            },
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
-            "tags": [],
             "tagsQuery": "",
             "type": "query",
             "useTags": false
@@ -2323,6 +2478,5 @@ spec:
       "timezone": "",
       "title": "Infrastructure Node View",
       "uid": "1F1OJZEWz",
-      "version": 28
+      "version": 1
     }
-


### PR DESCRIPTION
This syncs 1.2 boards with how 1.3 populates the host variable. Using this method minimizes the inclusion of unwanted hostnames in the "nodes" dropdown menu
