### PR TITLE
Ensure uniqueness of reference vector in instance panels

### DIFF
--- a/deploy/rhos-cloud-dashboard.yaml
+++ b/deploy/rhos-cloud-dashboard.yaml
@@ -1110,7 +1110,7 @@ spec:
           },
           "targets": [
             {
-              "expr": "label_replace(collectd_virt_if_octets_rx_total, \"resource\", \"$1\", \"host\", \".+:(.+):.+\") + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
+              "expr": "label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\") + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
               "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }

--- a/deploy/rhos-cloud-dashboard.yaml
+++ b/deploy/rhos-cloud-dashboard.yaml
@@ -1110,7 +1110,7 @@ spec:
           },
           "targets": [
             {
-              "expr": "label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\") + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
+              "expr": "sum by (resource, plugin_instance) (label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\")) + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
               "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }

--- a/deploy/stf-1.3/rhos-cloud-dashboard.yaml
+++ b/deploy/stf-1.3/rhos-cloud-dashboard.yaml
@@ -1766,7 +1766,7 @@ spec:
           ],
           "targets": [
             {
-              "expr": "label_replace(collectd_virt_if_octets_rx_total, \"resource\", \"$1\", \"host\", \".+:(.+):.+\") + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
+              "expr": "label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\") + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
               "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }

--- a/deploy/stf-1.3/rhos-cloud-dashboard.yaml
+++ b/deploy/stf-1.3/rhos-cloud-dashboard.yaml
@@ -1766,7 +1766,7 @@ spec:
           ],
           "targets": [
             {
-              "expr": "label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\") + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
+              "expr": "sum by (resource, plugin_instance) (label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\")) + on(resource) group_right(plugin_instance) ceilometer_cpu{project=\"$projects\"}",
               "legendFormat": "{{plugin_instance}}",
               "refId": "A"
             }


### PR DESCRIPTION
Unfortunately, no one metric provides information on which VMs are running in each OSP project (IOW, no one metric has all the labels we want). We must cross-reference a metrics from the collectd virt plugin and ceilometer to present that information in the cloud dashboard.  The PromQL query looks complicated at first glance so I will provide a basic explanation of what is happening:

The goal is to retrieve a unique vector for each VM running in a given OSP project. The values in the vector don't matter since all we are doing is showing that a VM exists. We can get information about the VM name from the collectd virt plugin, and we can get information about the OSP project a VM resides in from ceilometer metrics. Of course, each VM has a UID, and that UID is in both the collectd virt plugin and ceilometer metrics, thus we use that field to cross-reference the vectors. The `collectd_virt_memory` and `ceilometer_cpu` metrics were chosen to cross reference, but which metrics are used do no matter except that they both contain VM information and that one is from the collectd virt plugin and the other from ceilometer.

We take advantage of Prometheus "one-to-many" vector matching features.

## Vectors1 (the "one" vector in "one-to-many"):
Full: `sum by (resource) (label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\"))`
Requirement: A unique vector for each VM UID that also contains the VM name in a label
Breakdown:
section | description | return vector
-|-|-
`label_replace(collectd_virt_memory, \"resource\", \"$1\", \"host\", \".+:(.+):.+\"))`  |  extracts VM UID from host label and place in the `resource` label | the same vector with a new label called `resource` that has the VM UID in it
`sum by (resource, plugin_instance) (ABOVE)` | ensure there is only one vector for each (`resource`,`plugin_instance`) label pair | Only 1 vector for each (`resource`,`plugin_instance`) label pair, `plugin_instance` being the VM name and `resource` being the VM UID

## Vectors 2 ( the "many" side):
Full: `ceilometer_cpu{project=\"$projects\"}"`
Requirements: A unique vector for each VM UID that also contains information about which OSP project it is in
Breakdown:
section | description | return vector
-|-|-
`ceilometer_cpu{project=\"$projects\"}"` | get a vector filtered by OSP project ID | vector containing VM UID (`resource` label) and OSP Project ID information (`project` label)

## Matching the vectors
Full: ` + on(resource) group_right(plugin_instance)`
Requirements: return new vectors containing information about VM name and which OSP Project it belongs to, coupled together
Breakdown:
section | description
-|-
`+ on(resource)` | match vectors based on `resource` label (VM UID) and add them together.
`group_right(plugin_instance)` | ensure resulting vector from above addition contains the `plugin_instance` label (VM name) from the collectd virt metric so it can be displayed on the dashboard

Resolves: rhbz#1999291