### PR TITLE
Update alerts panel to not show pending alerts

### DIFF
--- a/deploy/stf-1.3/rhos-dashboard.yaml
+++ b/deploy/stf-1.3/rhos-dashboard.yaml
@@ -166,7 +166,7 @@ spec:
           ],
           "targets": [
             {
-              "expr": "ALERTS",
+              "expr": "ALERTS{alertstate!=\"pending\"}",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -305,7 +305,7 @@ spec:
           ],
           "targets": [
             {
-              "expr": "ALERTS",
+              "expr": "ALERTS{alertstate!=\"pending\"}",
               "format": "table",
               "hide": false,
               "instant": false,


### PR DESCRIPTION
Hide pending alerts from the global alerts panels on the rhos-dashboard.
This results in only showing active (firing) alerts rather than bounding
pending alerts in and out.

Closes: rhbz#1875854
