### PR TITLE
Enhance SG tracker dashboard

### DIFF
--- a/deploy/stf-1.3/sg-tracker-dashboard.yaml
+++ b/deploy/stf-1.3/sg-tracker-dashboard.yaml
@@ -8,33 +8,6 @@ metadata:
 spec:
   json: |
     {
-      "__inputs": [],
-      "__requires": [
-        {
-          "type": "panel",
-          "id": "bargauge",
-          "name": "Bar gauge",
-          "version": ""
-        },
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "8.0.4"
-        },
-        {
-          "type": "panel",
-          "id": "stat",
-          "name": "Stat",
-          "version": ""
-        },
-        {
-          "type": "panel",
-          "id": "timeseries",
-          "name": "Time series",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -62,6 +35,254 @@ spec:
             "w": 24,
             "x": 0,
             "y": 0
+          },
+          "id": 35,
+          "panels": [],
+          "title": "Collector Memory Usage",
+          "type": "row"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "id": 37,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "collectd_libpodstats_pod_memory{plugin_instance=\"collectd\"}",
+              "interval": "",
+              "legendFormat": "{{ host }}",
+              "refId": "A"
+            }
+          ],
+          "title": "collectd memory usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 38,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "collectd_libpodstats_pod_memory{plugin_instance=~\"ceilometer.*\"}",
+              "interval": "",
+              "legendFormat": "{{ host }} ({{ plugin_instance}})",
+              "refId": "A"
+            }
+          ],
+          "title": "ceilometer memory usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 39,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "collectd_libpodstats_pod_memory{plugin_instance=~\"rabbitmq.*|metrics_qdr\"}",
+              "interval": "",
+              "legendFormat": "{{ host }} ({{ plugin_instance}})",
+              "refId": "A"
+            }
+          ],
+          "title": "bus memory usage",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "datasource": null,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
           },
           "id": 2,
           "panels": [],
@@ -100,7 +321,7 @@ spec:
                   "mode": "none"
                 },
                 "thresholdsStyle": {
-                  "mode": "line"
+                  "mode": "line+area"
                 }
               },
               "mappings": [],
@@ -128,7 +349,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 1
+            "y": 10
           },
           "id": 6,
           "options": {
@@ -185,7 +406,7 @@ spec:
                   "mode": "none"
                 },
                 "thresholdsStyle": {
-                  "mode": "line"
+                  "mode": "line+area"
                 }
               },
               "mappings": [],
@@ -213,7 +434,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 1
+            "y": 10
           },
           "id": 4,
           "options": {
@@ -270,7 +491,7 @@ spec:
                   "mode": "none"
                 },
                 "thresholdsStyle": {
-                  "mode": "line"
+                  "mode": "line+area"
                 }
               },
               "mappings": [],
@@ -298,7 +519,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 1
+            "y": 10
           },
           "id": 8,
           "options": {
@@ -348,7 +569,7 @@ spec:
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 9
+            "y": 18
           },
           "id": 10,
           "options": {
@@ -369,7 +590,7 @@ spec:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -410,7 +631,7 @@ spec:
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 9
+            "y": 18
           },
           "id": 11,
           "options": {
@@ -431,7 +652,7 @@ spec:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -472,7 +693,7 @@ spec:
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 9
+            "y": 18
           },
           "id": 12,
           "options": {
@@ -493,7 +714,7 @@ spec:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -515,7 +736,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 15
+            "y": 24
           },
           "id": 14,
           "panels": [],
@@ -579,7 +800,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 16
+            "y": 25
           },
           "id": 16,
           "options": {
@@ -656,7 +877,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 16
+            "y": 25
           },
           "id": 18,
           "options": {
@@ -738,7 +959,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 16
+            "y": 25
           },
           "id": 20,
           "options": {
@@ -770,7 +991,7 @@ spec:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 33
           },
           "id": 22,
           "panels": [],
@@ -835,7 +1056,7 @@ spec:
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 25
+            "y": 34
           },
           "id": 25,
           "options": {
@@ -918,7 +1139,7 @@ spec:
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 25
+            "y": 34
           },
           "id": 24,
           "options": {
@@ -1001,7 +1222,7 @@ spec:
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 25
+            "y": 34
           },
           "id": 26,
           "options": {
@@ -1051,7 +1272,7 @@ spec:
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 32
+            "y": 41
           },
           "id": 27,
           "options": {
@@ -1072,7 +1293,7 @@ spec:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -1112,7 +1333,7 @@ spec:
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 32
+            "y": 41
           },
           "id": 29,
           "options": {
@@ -1133,7 +1354,7 @@ spec:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -1173,7 +1394,7 @@ spec:
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 32
+            "y": 41
           },
           "id": 28,
           "options": {
@@ -1194,7 +1415,7 @@ spec:
             },
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -1235,7 +1456,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 38
+            "y": 47
           },
           "id": 31,
           "options": {
@@ -1254,7 +1475,7 @@ spec:
               "valueSize": 24
             }
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -1295,7 +1516,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 38
+            "y": 47
           },
           "id": 32,
           "options": {
@@ -1314,7 +1535,7 @@ spec:
               "valueSize": 24
             }
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -1355,7 +1576,7 @@ spec:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 38
+            "y": 47
           },
           "id": 33,
           "options": {
@@ -1374,7 +1595,7 @@ spec:
               "valueSize": 24
             }
           },
-          "pluginVersion": "8.0.4",
+          "pluginVersion": "8.0.6",
           "targets": [
             {
               "exemplar": true,
@@ -1404,5 +1625,5 @@ spec:
       "timezone": "",
       "title": "Smart Gateway Tracker",
       "uid": "St-0HBm7z",
-      "version": 1
+      "version": 2
     }


### PR DESCRIPTION
Enhance the SG tracker dashboard by filling the background colour of the
thresholds defined for message receive count. If the message count
largely exceeds the threshold, the visual layer can become compressed in
such a way that it's not clear the threshold is being overrun.
Additionally, add a new panel row that shows the collectors and
transports memory usage.
