### PR TITLE
Ensure unique list of instances in virtual machine view

### DIFF
--- a/deploy/stf-1.3/virtual-machine-view.yaml
+++ b/deploy/stf-1.3/virtual-machine-view.yaml
@@ -394,7 +394,7 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "(ceilometer_cpu{project=\"$project\"}) + on (resource) group_right(project) label_replace(label_replace(collectd_virt_virt_vcpu_total, \"resource\", \"$1\", \"host\", \".+:(.+):.+\"), \"Node\", \"$1\", \"host\", \".+:.+:(.+)\")",
+              "expr": "(ceilometer_cpu{project=\"$project\"}) + on (resource) group_right(project) label_replace(label_replace(collectd_virt_virt_cpu_total_total, \"resource\", \"$1\", \"host\", \".+:(.+):.+\"), \"Node\", \"$1\", \"host\", \".+:.+:(.+)\")",
               "format": "table",
               "instant": true,
               "interval": "",


### PR DESCRIPTION
Metrics of `collectd_virt_virt_vcpu_total` correspond
to the number of vcpus used by all instances.

Due to which instances are enlisted multiple times depending upon
their vcpu count.

Replacing this metric with `collectd_virt_virt_cpu_total_total`
doesn't duplicate the instances in `Virtual Machines` column.

Fixes: #48

Signed-off-by: Yadnesh Kulkarni <ykulkarn@redhat.com>