### PR TITLE
Set VM dashboard annontation view off by default

### DIFF
--- a/deploy/stf-1.3/virtual-machine-view.yaml
+++ b/deploy/stf-1.3/virtual-machine-view.yaml
@@ -22,9 +22,9 @@ spec:
           },
           {
             "datasource": "es_ceilometer",
-            "enable": true,
+            "enable": false,
             "hide": false,
-            "iconColor": "green",
+            "iconColor": "#616161",
             "limit": 100,
             "name": "Compute Instance",
             "query": "labels.project_id: $project",

--- a/deploy/stf-1/virtual-machine-view.yaml
+++ b/deploy/stf-1/virtual-machine-view.yaml
@@ -22,9 +22,9 @@ spec:
           },
           {
             "datasource": "es_ceilometer",
-            "enable": true,
+            "enable": false,
             "hide": false,
-            "iconColor": "green",
+            "iconColor": "#616161",
             "limit": 100,
             "name": "Compute Instance",
             "query": "labels.project_id: $project",


### PR DESCRIPTION
Change the annotations for virtual machine checks in the virtual machine
dashboard view off by default. The Elasticsearch instance is not enabled
by default in our documentation or in a default ServiceTelemetry
manifest, so having this enabled by default can result in errors showing
up in the dashboard when you don't have the es_ceilometer data source.

Also changed the overlay colour from green to grey because the green
seemed a bit intense when looking at a 24 hour range (which is the
dashboard default).

Closes: rhbz#2173856
