### PR TITLE
`project` field can now list project names

### DIFF
--- a/deploy/stf-1/rhos-cloud-dashboard.yaml
+++ b/deploy/stf-1/rhos-cloud-dashboard.yaml
@@ -1595,7 +1595,7 @@ spec:
               "value": "$__all"
             },
             "datasource": "STFPrometheus",
-            "definition": "label_values(ceilometer_cpu{service=~\".+-$clouds-.+\"},project)",
+            "definition": "ceilometer_cpu{service=~\".+-$clouds-.+\"}",
             "description": null,
             "error": null,
             "hide": 2,
@@ -1605,11 +1605,11 @@ spec:
             "name": "projects",
             "options": [],
             "query": {
-              "query": "label_values(ceilometer_cpu{service=~\".+-$clouds-.+\"},project)",
+              "query": "ceilometer_cpu{service=~\".+-$clouds-.+\"}",
               "refId": "StandardVariableQuery"
             },
             "refresh": 2,
-            "regex": "",
+            "regex": "/project_name="(?<text>[^"]+)|project="(?<value>[^"]+)/g",
             "skipUrlSync": false,
             "sort": 0,
             "tagValuesQuery": "",

--- a/deploy/stf-1/virtual-machine-view.yaml
+++ b/deploy/stf-1/virtual-machine-view.yaml
@@ -1072,7 +1072,7 @@ spec:
           {
             "allValue": null,
             "datasource": null,
-            "definition": "label_values(ceilometer_cpu{service=~\".+-$clouds-.+\"}, project)",
+            "definition": "ceilometer_cpu{service=~".+-$clouds-.+"}",
             "description": null,
             "error": null,
             "hide": 0,
@@ -1082,11 +1082,11 @@ spec:
             "name": "project",
             "options": [],
             "query": {
-              "query": "label_values(ceilometer_cpu{service=~\".+-$clouds-.+\"}, project)",
+              "query": "ceilometer_cpu{service=~".+-$clouds-.+"}",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
-            "regex": "",
+            "regex": "/project_name="(?<text>[^"]+)|project="(?<value>[^"]+)/g",
             "skipUrlSync": false,
             "sort": 0,
             "tagValuesQuery": "",


### PR DESCRIPTION
If `CeilometerEnableTenantDiscovery` is enabled, ceilometer samples will contain `project_name` field, values from which are populated in `project` field.

This change affects 2 dashboards, 'Cloud View' and 'Virtual Machine View', only these allow switching between openstack projects.

If samples are missing `project_name` field, the regex for `project` variable allows fallback to `project` field